### PR TITLE
docs: establish StageTrack product foundation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,240 @@
+# StageTrack — Arquitetura Inicial
+
+## Stack
+
+- Next.js
+- TypeScript
+- Tailwind CSS
+- React Hook Form
+- Zod
+- Firebase Authentication
+- Cloud Firestore
+- Firebase Storage
+- Vercel
+
+## Estratégia
+
+O StageTrack será inicialmente uma aplicação web responsiva em um único projeto Next.js. O Firebase fornecerá autenticação, persistência e armazenamento de arquivos. O MVP não terá backend separado.
+
+```text
+Next.js
+   ↓
+Firebase SDK
+   ├── Authentication
+   ├── Firestore
+   └── Storage
+```
+
+## Estrutura sugerida
+
+```text
+stagetrack/
+├── .github/
+│   └── workflows/
+├── docs/
+├── public/
+├── src/
+│   ├── app/
+│   ├── components/
+│   ├── features/
+│   ├── hooks/
+│   ├── lib/
+│   ├── schemas/
+│   ├── services/
+│   ├── types/
+│   └── utils/
+├── firestore.rules
+├── firestore.indexes.json
+├── firebase.json
+├── .firebaserc
+├── .env.example
+└── README.md
+```
+
+## Organização por domínio
+
+```text
+src/features/
+├── auth/
+├── users/
+├── internships/
+├── internship-types/
+├── organizations/
+├── supervisors/
+└── activities/
+```
+
+Cada domínio poderá conter seus próprios `components`, `services`, `schemas`, `types`, `hooks` e `utils` quando necessário.
+
+## Acesso a dados
+
+Chamadas ao Firestore não devem ficar espalhadas pela interface. Serviços/repositories concentrarão operações como:
+
+```text
+internshipRepository
+- createInternship()
+- getInternship()
+- getStudentInternships()
+- updateInternship()
+
+activityRepository
+- createActivity()
+- updateActivity()
+- deleteActivity()
+- getInternshipActivities()
+```
+
+## Coleções iniciais
+
+```text
+/users/{userId}
+/courses/{courseId}
+/internshipTypes/{internshipTypeId}
+/organizations/{organizationId}
+/supervisors/{supervisorId}
+/internships/{internshipId}
+/activityLogs/{activityLogId}
+```
+
+Coleções futuras:
+
+```text
+/documents
+/notifications
+/auditLogs
+```
+
+## Modelos principais
+
+### User
+
+```text
+id
+name
+email
+role
+courseId
+registrationNumber
+createdAt
+updatedAt
+```
+
+### Internship
+
+```text
+id
+studentId
+internshipTypeId
+organizationId
+supervisorId
+advisorId
+startDate
+expectedEndDate
+requiredMinutes
+status
+createdAt
+updatedAt
+```
+
+### ActivityLog
+
+```text
+id
+internshipId
+studentId
+date
+startTime
+endTime
+durationMinutes
+classGroup
+teacherName
+description
+notes
+status
+advisorComment
+createdAt
+updatedAt
+```
+
+## Tempo e carga horária
+
+A fonte de verdade para duração será `durationMinutes`, nunca horas decimais.
+
+Exemplo:
+
+```text
+13:00 → 17:30 = 270 minutos
+```
+
+Horas cumpridas, horas restantes e percentual serão valores derivados dos registros.
+
+## Autenticação
+
+O UID do Firebase Authentication será utilizado como ID do documento do usuário no Firestore:
+
+```text
+Firebase Authentication
+       ↓
+      UID
+       ↓
+/users/{uid}
+```
+
+## Segurança
+
+A interface não será considerada uma barreira de segurança. As regras do Firestore deverão impedir acesso cruzado entre alunos e preparar autorização para orientadores e coordenação.
+
+## Rotas iniciais
+
+Públicas:
+
+```text
+/
+/login
+/register
+/forgot-password
+```
+
+Privadas:
+
+```text
+/dashboard
+/internships
+/internships/*
+/activities
+/profile
+```
+
+## Qualidade
+
+Antes de mergear funcionalidades relevantes:
+
+```text
+lint
+typecheck
+build
+```
+
+Testes automatizados serão adicionados progressivamente, priorizando cálculos, regras e fluxos críticos.
+
+## Convenções Git
+
+Conventional Commits:
+
+```text
+feat: add internship creation flow
+fix: prevent invalid activity duration
+docs: update product requirements
+refactor: isolate firestore repository
+test: add duration calculation tests
+```
+
+Branches:
+
+```text
+feat/*
+fix/*
+docs/*
+refactor/*
+test/*
+```

--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -1,0 +1,64 @@
+# StageTrack — Product Vision
+
+## Visão
+
+O StageTrack é uma plataforma web para acompanhamento de estágios supervisionados obrigatórios. O produto centraliza pessoas, atividades, carga horária, documentação e acompanhamento acadêmico em um único ambiente.
+
+## Problema
+
+O controle de estágio costuma ficar fragmentado entre planilhas, papéis, formulários, arquivos e acompanhamento manual. Isso dificulta o cálculo de horas, a organização documental, a identificação de pendências e a produção de relatórios.
+
+## Objetivo geral
+
+Desenvolver uma plataforma simples e confiável para registrar, acompanhar e gerenciar a jornada acadêmica de estágio.
+
+## Público inicial
+
+- estudantes;
+- professores orientadores;
+- coordenações de estágio;
+- instituições de ensino.
+
+## Proposta de valor
+
+Tornar o estágio supervisionado mais organizado, transparente e fácil de acompanhar, reduzindo controles manuais e centralizando as informações relevantes.
+
+## Perfis
+
+### Aluno
+
+Cadastra o estágio, registra atividades, acompanha horas, envia documentos e consulta seu progresso.
+
+### Professor orientador
+
+Acompanha orientandos, consulta registros e futuramente valida atividades e documentos.
+
+### Coordenação
+
+Acompanha o panorama geral, modalidades, estágios, pendências e situações de risco.
+
+## MVP do aluno
+
+O primeiro marco do StageTrack será atingido quando um aluno conseguir:
+
+1. criar conta e fazer login;
+2. cadastrar seu estágio;
+3. vincular modalidade e instituição;
+4. registrar uma atividade com data e horários;
+5. ter a duração calculada automaticamente;
+6. acompanhar horas cumpridas, restantes e percentual;
+7. consultar o histórico de atividades.
+
+## Fora do primeiro MVP
+
+- aplicativo nativo;
+- WhatsApp;
+- assinatura digital;
+- IA;
+- integração com sistemas acadêmicos;
+- gestão financeira;
+- vagas e convênios.
+
+## Evolução
+
+Após o MVP do aluno, o produto poderá incorporar orientadores, coordenação, documentos, relatórios, alertas, previsão de conclusão e geração assistida de relatórios.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,0 +1,104 @@
+# StageTrack — Requisitos do Produto
+
+## Perfis
+
+- `student`: aluno
+- `advisor`: professor orientador
+- `coordinator`: coordenação
+
+## Requisitos funcionais do núcleo
+
+### Autenticação
+
+- **RF001** — permitir cadastro de usuário.
+- **RF002** — permitir login por e-mail e senha.
+- **RF003** — permitir logout.
+- **RF004** — permitir recuperação de senha.
+
+### Usuário
+
+- **RF005** — permitir visualizar o próprio perfil.
+- **RF006** — permitir editar dados autorizados do próprio perfil.
+- **RF007** — permitir matrícula acadêmica para alunos.
+- **RF008** — associar aluno a um curso.
+
+### Modalidades de estágio
+
+- **RF009** — permitir cadastrar modalidades de estágio.
+- **RF010** — cada modalidade deve possuir carga horária obrigatória.
+- **RF011** — modalidade pode possuir descrição e orientações.
+- **RF012** — modalidade pode ser ativada ou desativada.
+
+### Instituições
+
+- **RF013** — permitir cadastrar instituição concedente.
+- **RF014** — armazenar dados básicos da instituição.
+- **RF015** — permitir reutilizar uma instituição em diferentes estágios.
+
+### Estágio
+
+- **RF016** — permitir ao aluno criar um estágio.
+- **RF017** — vincular estágio a uma modalidade.
+- **RF018** — vincular estágio a uma instituição.
+- **RF019** — permitir supervisor e orientador.
+- **RF020** — armazenar data inicial e data prevista de término.
+- **RF021** — manter status do estágio: `draft`, `active`, `paused`, `completed`, `cancelled`.
+- **RF022** — permitir visualizar o próprio estágio e histórico de estágios.
+
+### Atividades
+
+- **RF023** — permitir registrar atividade de estágio.
+- **RF024** — registro deve possuir data, início, fim e descrição.
+- **RF025** — permitir turma, professor responsável e observações.
+- **RF026** — calcular automaticamente a duração.
+- **RF027** — permitir edição e exclusão enquanto o registro não estiver validado.
+- **RF028** — listar registros em ordem cronológica.
+
+### Carga horária
+
+- **RF029** — somar a duração dos registros válidos.
+- **RF030** — calcular horas restantes.
+- **RF031** — calcular percentual de conclusão.
+- **RF032** — rejeitar horário final anterior ou igual ao inicial.
+
+### Dashboard do aluno
+
+- **RF033** — exibir horas cumpridas.
+- **RF034** — exibir horas restantes.
+- **RF035** — exibir percentual de conclusão.
+- **RF036** — exibir status do estágio e atividades recentes.
+
+## Requisitos pós-MVP
+
+- validação de atividades por orientador;
+- comentários de revisão;
+- painel de orientandos;
+- dashboard da coordenação;
+- documentos e estados de aprovação;
+- geração de relatórios e PDF;
+- alertas e previsão de conclusão.
+
+## Regras de negócio
+
+- **RN001** — aluno só pode alterar seus próprios estágios e registros.
+- **RN002** — professor só acessa orientandos autorizados.
+- **RN003** — coordenação acessa apenas seu contexto institucional.
+- **RN004** — todo estágio deve possuir modalidade.
+- **RN005** — carga obrigatória da modalidade deve ser maior que zero.
+- **RN006** — estágio só pode ser concluído ao atingir a carga mínima obrigatória.
+- **RN007** — duração deve ser armazenada em minutos.
+- **RN008** — registros rejeitados não contam como carga validada.
+- **RN009** — registros validados não podem ser editados pelo aluno.
+- **RN010** — não é permitido registrar atividades em estágio concluído ou cancelado.
+- **RN011** — histórico de estágios concluídos deve ser preservado.
+- **RN012** — progresso visual é limitado a 100%, mesmo que a carga registrada ultrapasse a mínima.
+
+## Requisitos não funcionais
+
+- **RNF001** — interface responsiva.
+- **RNF002** — rotas privadas exigem autenticação.
+- **RNF003** — autorização deve ser validada também no backend/regras do Firestore.
+- **RNF004** — dados devem possuir persistência confiável.
+- **RNF005** — interface deve priorizar clareza e usabilidade.
+- **RNF006** — consultas devem carregar apenas os dados necessários.
+- **RNF007** — arquitetura deve permitir evolução para auditoria e múltiplas instituições.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,122 @@
+# StageTrack — Roadmap Inicial
+
+## Objetivo do roadmap
+
+Evoluir o StageTrack em ciclos pequenos, priorizando um primeiro produto realmente utilizável por estudantes antes de adicionar recursos institucionais mais complexos.
+
+## Sprint 0 — Foundation
+
+Objetivo: preparar a base técnica do produto.
+
+- inicializar aplicação Next.js;
+- estruturar diretórios;
+- configurar Firebase;
+- implementar fundação de autenticação;
+- criar modelo de usuário;
+- criar telas de login, cadastro e recuperação;
+- proteger rotas privadas;
+- criar layout autenticado;
+- criar dashboard placeholder;
+- adicionar regras iniciais do Firestore;
+- consolidar documentação;
+- configurar CI com lint, typecheck e build.
+
+### Definition of Done
+
+A Sprint 0 estará concluída quando:
+
+- aplicação rodar localmente;
+- build passar;
+- deploy inicial existir;
+- Firebase estiver conectado;
+- cadastro e login funcionarem;
+- dashboard exigir autenticação;
+- regras básicas do Firestore existirem;
+- documentação estiver versionada;
+- CI estiver executando com sucesso.
+
+## Sprint 1 — Internship Foundation
+
+Objetivo: permitir ao estudante cadastrar e visualizar seu estágio.
+
+- modalidades de estágio;
+- instituições;
+- cadastro do estágio;
+- visualização do estágio;
+- status do estágio;
+- dashboard com dados reais.
+
+## Sprint 2 — Activity Tracking
+
+Objetivo: tornar o StageTrack utilizável no dia a dia.
+
+- registro de atividades;
+- cálculo automático de duração;
+- histórico de atividades;
+- edição e exclusão conforme regras;
+- soma das horas;
+- horas restantes;
+- percentual de conclusão.
+
+### Primeiro grande marco
+
+Ao final da Sprint 2, o aluno deverá conseguir:
+
+```text
+Criar conta
+   ↓
+Cadastrar estágio
+   ↓
+Registrar atividades
+   ↓
+Acompanhar horas
+   ↓
+Visualizar progresso
+```
+
+Esse marco será chamado de **StageTrack Student MVP**.
+
+## Sprint 3 — Academic Tracking
+
+- professor orientador;
+- lista de orientandos;
+- envio de registros para análise;
+- aprovação e rejeição;
+- comentários do orientador;
+- carga registrada x carga validada.
+
+## Sprint 4 — Documents
+
+- documentos obrigatórios;
+- upload;
+- status;
+- revisão;
+- pendências.
+
+## Sprint 5 — Reports
+
+- relatório cronológico de atividades;
+- resumo de carga horária;
+- ficha de frequência;
+- exportação em PDF.
+
+## Sprint 6 — Coordination
+
+- dashboard institucional;
+- filtros;
+- alunos em risco;
+- estágios ativos e concluídos;
+- modalidades e configurações por curso.
+
+## Pós-1.0
+
+Possibilidades futuras:
+
+- previsão inteligente de conclusão;
+- notificações;
+- calendário;
+- geração assistida de relatórios com IA;
+- assinatura digital;
+- integração com sistemas acadêmicos;
+- múltiplas instituições de ensino;
+- PWA e experiência mobile aprimorada.


### PR DESCRIPTION
## Resumo

Estabelece a fundação inicial do StageTrack antes da implementação do produto.

### Documentação adicionada
- `docs/PRODUCT_VISION.md`
- `docs/REQUIREMENTS.md`
- `docs/ARCHITECTURE.md`
- `docs/ROADMAP.md`

### Decisões registradas
- visão e proposta de valor;
- escopo do Student MVP;
- requisitos funcionais e regras de negócio;
- stack e arquitetura inicial;
- modelo preliminar de dados;
- estratégia de segurança e autenticação;
- roadmap de Sprint 0 até evolução institucional.

## Próximo passo

Iniciar a STG-001 com a criação da aplicação Next.js e seguir o backlog da Sprint 0.

Closes #11