### PR TITLE
chore: organize StageTrack source structure

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,5 @@
+# Shared components
+
+Componentes reutilizáveis e agnósticos de domínio. Componentes específicos de uma funcionalidade devem permanecer dentro de `src/features/<feature>/components`.
+
+Subgrupos esperados futuramente: `ui`, `layout`, `forms` e `feedback`.

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -1,0 +1,5 @@
+# Features
+
+Código organizado por domínio de negócio. Cada feature pode ter seus próprios `components`, `hooks`, `services`, `schemas`, `types` e `utils` quando necessário.
+
+Domínios planejados: `auth`, `users`, `internships`, `internship-types`, `organizations`, `supervisors` e `activities`.

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -1,0 +1,3 @@
+# Shared hooks
+
+Hooks React reutilizáveis entre múltiplos domínios. Hooks específicos de uma feature devem permanecer em `src/features/<feature>/hooks`.

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -1,0 +1,3 @@
+# Lib
+
+Integrações e configurações de bibliotecas externas usadas pela aplicação, como Firebase, validação e utilitários de infraestrutura. Evitar lógica de negócio nesta camada.

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -1,0 +1,3 @@
+# Shared schemas
+
+Schemas de validação reutilizados por múltiplos domínios. Schemas específicos devem permanecer junto da feature responsável.

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,3 @@
+# Shared services
+
+Serviços e repositories compartilhados entre domínios. Acesso a Firebase e outras fontes de dados deve ser centralizado, evitando chamadas diretas espalhadas pela interface.

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -1,0 +1,3 @@
+# Shared types
+
+Tipos TypeScript compartilhados por múltiplos domínios. Tipos de negócio específicos devem ficar próximos da feature correspondente.

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -1,0 +1,3 @@
+# Shared utilities
+
+Funções puras e utilitários reutilizáveis. Regras de negócio específicas devem permanecer dentro do domínio responsável.


### PR DESCRIPTION
## Resumo

Implementa a STG-002 estruturando as camadas-base do código conforme `docs/ARCHITECTURE.md`.

### Estrutura adicionada
- `src/components`
- `src/features`
- `src/hooks`
- `src/lib`
- `src/schemas`
- `src/services`
- `src/types`
- `src/utils`

Cada camada possui documentação curta de responsabilidade. A organização prioriza código por domínio em `src/features`, evitando concentrar lógica de negócio em pastas genéricas.

## Critérios da STG-002
- [x] diretórios criados;
- [x] estrutura coerente com `docs/ARCHITECTURE.md`;
- [x] responsabilidade das camadas documentada;
- [x] nenhum código de domínio movido para componentes genéricos.

Closes #2