### PR TITLE
feat: add secured user profile model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   quality:
@@ -19,15 +19,27 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
+
+      - name: Commit refreshed lockfile
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ -n "$(git status --porcelain -- package-lock.json)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add package-lock.json
+            git commit -m "chore: refresh npm lockfile"
+            git push origin HEAD:${{ github.head_ref }}
+          fi
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   quality:
@@ -19,27 +19,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
-
-      - name: Commit refreshed lockfile
-        if: github.event_name == 'pull_request'
-        run: |
-          if [ -n "$(git status --porcelain -- package-lock.json)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add package-lock.json
-            git commit -m "chore: refresh npm lockfile"
-            git push origin HEAD:${{ github.head_ref }}
-          fi
+        run: npm ci
 
       - name: Lint
         run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@supabase/supabase-js": "2.112.4",
         "next": "16.3.3",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "zod": "4.5.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.0",
@@ -6887,7 +6888,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
       "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@supabase/supabase-js": "2.112.4",
     "next": "16.3.3",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.0",

--- a/src/features/users/index.ts
+++ b/src/features/users/index.ts
@@ -1,0 +1,15 @@
+export {
+  createCurrentProfile,
+  getCurrentProfile,
+  updateCurrentProfile,
+} from "./repositories/profile.repository";
+
+export { profileInputSchema } from "./schemas/profile.schema";
+
+export type { ProfileInput } from "./schemas/profile.schema";
+export type {
+  Profile,
+  ProfileRepositoryError,
+  ProfileResult,
+  UserRole,
+} from "./types";

--- a/src/features/users/repositories/profile.repository.ts
+++ b/src/features/users/repositories/profile.repository.ts
@@ -1,0 +1,143 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import { createClient } from "@/lib/supabase/server";
+
+import {
+  profileInputSchema,
+  type ProfileInput,
+} from "../schemas/profile.schema";
+import type { Profile, ProfileResult } from "../types";
+
+const PROFILE_COLUMNS =
+  "id,full_name,role,registration_number,created_at,updated_at" as const;
+
+function repositoryError(
+  code: string,
+  message: string,
+): ProfileResult<never> {
+  return { ok: false, error: { code, message } };
+}
+
+function databaseError(error: PostgrestError): ProfileResult<never> {
+  return repositoryError(error.code, error.message);
+}
+
+async function getAuthenticatedUserId() {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+  const userId = data?.claims?.sub;
+
+  if (error || !userId) {
+    return {
+      ok: false as const,
+      error: {
+        code: error?.code ?? "not_authenticated",
+        message: error?.message ?? "Authenticated user is required.",
+      },
+    };
+  }
+
+  return { ok: true as const, supabase, userId };
+}
+
+function parseProfileInput(input: ProfileInput) {
+  const parsed = profileInputSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      ok: false as const,
+      error: {
+        code: "invalid_profile_input",
+        message: parsed.error.issues[0]?.message ?? "Invalid profile data.",
+      },
+    };
+  }
+
+  return { ok: true as const, data: parsed.data };
+}
+
+export async function getCurrentProfile(): Promise<
+  ProfileResult<Profile | null>
+> {
+  const auth = await getAuthenticatedUserId();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("profiles")
+    .select(PROFILE_COLUMNS)
+    .eq("id", auth.userId)
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function createCurrentProfile(
+  input: ProfileInput,
+): Promise<ProfileResult<Profile>> {
+  const parsed = parseProfileInput(input);
+
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.error };
+  }
+
+  const auth = await getAuthenticatedUserId();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("profiles")
+    .insert({
+      id: auth.userId,
+      full_name: parsed.data.fullName,
+      registration_number: parsed.data.registrationNumber ?? null,
+    })
+    .select(PROFILE_COLUMNS)
+    .single();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function updateCurrentProfile(
+  input: ProfileInput,
+): Promise<ProfileResult<Profile>> {
+  const parsed = parseProfileInput(input);
+
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.error };
+  }
+
+  const auth = await getAuthenticatedUserId();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("profiles")
+    .update({
+      full_name: parsed.data.fullName,
+      registration_number: parsed.data.registrationNumber ?? null,
+    })
+    .eq("id", auth.userId)
+    .select(PROFILE_COLUMNS)
+    .single();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}

--- a/src/features/users/schemas/profile.schema.ts
+++ b/src/features/users/schemas/profile.schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+const registrationNumberSchema = z.preprocess(
+  (value) => {
+    if (typeof value === "string" && value.trim().length === 0) {
+      return null;
+    }
+
+    return value;
+  },
+  z.string().trim().min(1).max(50).nullable().optional(),
+);
+
+export const profileInputSchema = z.object({
+  fullName: z.string().trim().min(2).max(120),
+  registrationNumber: registrationNumberSchema,
+});
+
+export type ProfileInput = z.output<typeof profileInputSchema>;

--- a/src/features/users/types.ts
+++ b/src/features/users/types.ts
@@ -1,0 +1,13 @@
+import type { Enums, Tables } from "@/types/database";
+
+export type UserRole = Enums<"app_role">;
+export type Profile = Tables<"profiles">;
+
+export type ProfileRepositoryError = {
+  code: string;
+  message: string;
+};
+
+export type ProfileResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: ProfileRepositoryError };

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,5 +1,7 @@
 import { createBrowserClient } from "@supabase/ssr";
 
+import type { Database } from "@/types/database";
+
 export function createClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
@@ -10,5 +12,5 @@ export function createClient() {
     );
   }
 
-  return createBrowserClient(url, publishableKey);
+  return createBrowserClient<Database>(url, publishableKey);
 }

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
+import type { Database } from "@/types/database";
+
 export async function updateSession(request: NextRequest) {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
@@ -13,7 +15,7 @@ export async function updateSession(request: NextRequest) {
 
   let supabaseResponse = NextResponse.next({ request });
 
-  const supabase = createServerClient(url, publishableKey, {
+  const supabase = createServerClient<Database>(url, publishableKey, {
     cookies: {
       getAll() {
         return request.cookies.getAll();
@@ -36,8 +38,6 @@ export async function updateSession(request: NextRequest) {
     },
   });
 
-  // getClaims validates the JWT and allows @supabase/ssr to refresh the
-  // cookie-backed session when necessary. Route authorization is added later.
   await supabase.auth.getClaims();
 
   return supabaseResponse;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
+import type { Database } from "@/types/database";
+
 export async function createClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
@@ -13,7 +15,7 @@ export async function createClient() {
 
   const cookieStore = await cookies();
 
-  return createServerClient(url, publishableKey, {
+  return createServerClient<Database>(url, publishableKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll();
@@ -24,8 +26,8 @@ export async function createClient() {
             cookieStore.set(name, value, options);
           });
         } catch {
-          // Server Components cannot always write cookies. Session refresh will
-          // be handled at the request boundary when authentication is added.
+          // Server Components cannot always write cookies. Session refresh is
+          // handled at the request boundary by the Next.js Proxy.
         }
       },
     },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,0 +1,181 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  __InternalSupabase: {
+    PostgrestVersion: "14.5";
+  };
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          created_at: string;
+          full_name: string;
+          id: string;
+          registration_number: string | null;
+          role: Database["public"]["Enums"]["app_role"];
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          full_name: string;
+          id: string;
+          registration_number?: string | null;
+          role?: Database["public"]["Enums"]["app_role"];
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          full_name?: string;
+          id?: string;
+          registration_number?: string | null;
+          role?: Database["public"]["Enums"]["app_role"];
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      app_role: "student" | "advisor" | "coordinator";
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never;
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never;
+
+export const Constants = {
+  public: {
+    Enums: {
+      app_role: ["student", "advisor", "coordinator"],
+    },
+  },
+} as const;

--- a/supabase/migrations/20260902024644_create_user_profiles.sql
+++ b/supabase/migrations/20260902024644_create_user_profiles.sql
@@ -1,0 +1,85 @@
+create type public.app_role as enum ('student', 'advisor', 'coordinator');
+
+create table public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  full_name text not null,
+  role public.app_role not null default 'student',
+  registration_number text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint profiles_full_name_length
+    check (char_length(btrim(full_name)) between 2 and 120),
+  constraint profiles_registration_number_length
+    check (
+      registration_number is null
+      or char_length(btrim(registration_number)) between 1 and 50
+    )
+);
+
+comment on table public.profiles is
+  'Application profile linked one-to-one with Supabase Auth users.';
+comment on column public.profiles.role is
+  'Authorization role. Client-created profiles always start as student.';
+
+create function public.set_profile_updated_at()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger profiles_set_updated_at
+before update on public.profiles
+for each row
+execute function public.set_profile_updated_at();
+
+revoke all on function public.set_profile_updated_at()
+from public, anon, authenticated;
+
+alter table public.profiles enable row level security;
+
+revoke all on table public.profiles from public, anon, authenticated;
+grant select on table public.profiles to authenticated;
+grant insert (id, full_name, registration_number)
+  on table public.profiles to authenticated;
+grant update (full_name, registration_number)
+  on table public.profiles to authenticated;
+grant select, insert, update, delete
+  on table public.profiles to service_role;
+
+create policy profiles_select_own
+on public.profiles
+for select
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and (select auth.uid()) = id
+);
+
+create policy profiles_insert_own_as_student
+on public.profiles
+for insert
+to authenticated
+with check (
+  (select auth.uid()) is not null
+  and (select auth.uid()) = id
+  and role = 'student'::public.app_role
+);
+
+create policy profiles_update_own
+on public.profiles
+for update
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and (select auth.uid()) = id
+)
+with check (
+  (select auth.uid()) is not null
+  and (select auth.uid()) = id
+);


### PR DESCRIPTION
## Resumo

Implementa a STG-005 com o primeiro modelo persistente do StageTrack em PostgreSQL.

### Banco de dados
- `public.profiles` ligado 1:1 a `auth.users(id)` com `ON DELETE CASCADE`;
- enum `app_role`: `student`, `advisor`, `coordinator`;
- novos perfis começam como `student`;
- trigger `security invoker` para `updated_at`;
- migration oficial `20260902024644_create_user_profiles.sql`.

### Segurança
- RLS habilitado;
- SELECT, INSERT e UPDATE restritos ao próprio `auth.uid()`;
- cliente não possui DELETE;
- cliente não possui privilégio para inserir ou alterar `role`;
- promoção para `advisor`/`coordinator` permanece administrativa;
- advisors do Supabase: zero alertas de segurança e zero de performance.

### Aplicação
- tipos TypeScript gerados diretamente do Supabase;
- clientes browser/server/proxy tipados com `Database`;
- Zod 4.5.4 para validação do perfil;
- repository centralizado para ler, criar e editar o próprio perfil;
- repository nunca aceita `role` como entrada e usa filtro explícito por ID;
- `package-lock.json` atualizado e CI restaurada para somente leitura + `npm ci`.

### Validação de permissões efetivas
- RLS: ativo;
- SELECT: permitido para authenticated + RLS;
- DELETE: negado;
- INSERT de `role`: negado;
- UPDATE de `role`: negado;
- UPDATE de `full_name`: permitido + RLS.

### Validação final
- [x] migration aplicada no `stagetrack-dev`;
- [x] security advisor sem alertas;
- [x] performance advisor sem alertas;
- [x] `npm ci`;
- [x] `npm run lint`;
- [x] `npm run typecheck`;
- [x] `npm run build`.

Closes #5