### PR TITLE
feat: protect authenticated application routes

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -41,6 +41,8 @@ O cliente de browser é usado apenas em Client Components quando necessário.
 
 O cliente de servidor é criado por requisição e lê a sessão dos cookies. Ele não deve ser armazenado em estado global ou reutilizado entre usuários.
 
+No servidor, `cookies()` é lido antes da criação/uso do cliente Supabase. Isso marca a operação como dependente da requisição no Next.js e evita que páginas autenticadas sejam tratadas como conteúdo estático durante o build.
+
 ## Renovação da sessão
 
 O Next.js Proxy executa:
@@ -55,15 +57,80 @@ auth.getClaims()
 
 `getClaims()` valida o JWT e permite que `@supabase/ssr` renove a sessão quando necessário.
 
-Os cookies e headers de cache retornados durante a renovação devem ser propagados para a resposta. Isso evita sessões inconsistentes e respostas autenticadas sendo cacheadas incorretamente.
+Os cookies e headers de cache retornados durante a renovação são propagados para a resposta. Isso evita sessões inconsistentes e respostas autenticadas sendo cacheadas incorretamente.
+
+Quando o Proxy precisa criar uma resposta de redirecionamento, os cookies renovados e os headers `Cache-Control`, `Expires` e `Pragma` da resposta Supabase também são copiados para o redirect.
 
 ## Autorização no servidor
 
 Não usar `auth.getSession()` como prova de identidade ou autorização no servidor.
 
-Para proteger páginas e dados, utilizar `auth.getClaims()` ou, quando for necessário buscar o registro de usuário mais recente no servidor de Auth, `auth.getUser()`.
+Para proteger páginas e dados, utilizar `auth.getClaims()` ou, quando for necessário buscar o registro mais recente do usuário no servidor de Auth, `auth.getUser()`.
 
-A proteção efetiva das rotas privadas será implementada na STG-007. Nesta etapa o Proxy apenas mantém a sessão atualizada.
+A proteção de rotas utiliza defesa em profundidade:
+
+```text
+Requisição
+   ↓
+Next.js Proxy
+   ↓  getClaims()
+Validação/redirect antecipado
+   ↓
+Layout (protected)
+   ↓  getClaims()
+Revalidação server-side
+   ↓
+Página privada + dados protegidos por RLS
+```
+
+O Proxy reduz trabalho desnecessário ao interromper cedo acessos inválidos. O layout privado continua validando a identidade no servidor para que a segurança da área autenticada não dependa exclusivamente da configuração do Proxy.
+
+## Política de rotas
+
+As rotas privadas iniciais são:
+
+```text
+/dashboard
+/internships
+/activities
+/profile
+```
+
+Sem claims válidas, qualquer uma dessas rotas redireciona para `/login`.
+
+Usuários já autenticados que acessarem as páginas de entrada abaixo são enviados para `/dashboard`:
+
+```text
+/login
+/register
+/forgot-password
+```
+
+`/reset-password` é propositalmente excluída desse redirect. O fluxo de recuperação pode criar uma sessão autenticada temporária antes de o usuário definir a nova senha.
+
+Após login ou cadastro que gere uma sessão imediatamente, a aplicação entra pela rota `/dashboard`.
+
+O logout é executado por Server Action, encerra a sessão no Supabase e redireciona para `/login`.
+
+## Cache de áreas autenticadas
+
+O layout `src/app/(protected)/layout.tsx` declara:
+
+```ts
+export const dynamic = "force-dynamic";
+```
+
+Rotas dependentes de identidade não devem usar ISR ou cache compartilhável. Além da validação por requisição, respostas que renovam sessão carregam os headers de cache produzidos pelo `@supabase/ssr`.
+
+Isso reduz o risco de conteúdo ou cookies de uma sessão serem reutilizados para outra requisição em infraestrutura com CDN ou instâncias serverless reutilizadas.
+
+## Dados do perfil
+
+A identidade vem do JWT validado pelo Supabase Auth. Dados de aplicação — como nome, matrícula e papel — ficam em `public.profiles` e são protegidos por Row Level Security.
+
+O papel (`student`, `advisor`, `coordinator`) não é confiado a `user_metadata`. O fluxo público cria perfis como `student`, e promoção de papel permanece uma operação administrativa.
+
+A rota `/profile` lê o perfil real do usuário autenticado através do repository de usuários, mantendo RLS e filtro explícito pelo UID.
 
 ## Fluxos de retorno
 
@@ -91,7 +158,7 @@ Essa rota deixa a aplicação preparada para templates de e-mail SSR baseados em
 
 O projeto de desenvolvimento usa o serviço de e-mail padrão do Supabase enquanto estiver no plano Free. Esse serviço possui limitações e não deve ser tratado como infraestrutura de produção.
 
-A aplicação não deve depender de customização de templates para funcionar durante a fase inicial. Quando houver domínio e ambiente de produção, SMTP próprio deverá ser avaliado.
+A aplicação não depende de customização de templates para funcionar durante a fase inicial. Quando houver domínio e ambiente de produção, SMTP próprio deverá ser avaliado.
 
 ## URLs de redirecionamento
 
@@ -103,6 +170,8 @@ http://localhost:3000/auth/confirm
 ```
 
 Quando houver deploy, os domínios da Vercel/produção deverão ser adicionados à allow list antes dos testes de confirmação e recuperação de senha.
+
+Links sensíveis iniciados pela aplicação usam `NEXT_PUBLIC_SITE_URL` em vez de construir a origem a partir do header `Host` da requisição.
 
 ## Chaves
 
@@ -120,7 +189,7 @@ Nunca expor no navegador ou versionar:
 - senha do banco;
 - tokens de acesso administrativos.
 
-A segurança dos dados acessíveis pelo cliente será garantida principalmente por autenticação, grants adequados e Row Level Security.
+A segurança dos dados acessíveis pelo cliente é garantida principalmente por autenticação, grants adequados e Row Level Security.
 
 ## Dependências reproduzíveis
 
@@ -128,8 +197,9 @@ As versões diretas do Supabase são fixadas em `package.json` e a árvore compl
 
 A CI utiliza `npm ci`, portanto qualquer divergência entre o manifesto e o lockfile deve falhar antes dos checks de qualidade.
 
-## Próximas etapas
+## Estado da fundação de autenticação
 
-- STG-005: modelo de perfil de usuário e RLS;
-- STG-006: telas de login, cadastro e recuperação;
-- STG-007: proteção das rotas privadas.
+- STG-004 — fundação Supabase Auth e SSR: concluída;
+- STG-005 — perfil de usuário e RLS: concluída;
+- STG-006 — telas e fluxos de autenticação: concluída;
+- STG-007 — proteção de rotas privadas e shell autenticado: em validação.

--- a/src/app/(protected)/activities/page.tsx
+++ b/src/app/(protected)/activities/page.tsx
@@ -1,0 +1,28 @@
+export default function ActivitiesPage() {
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <p className="text-sm font-semibold text-indigo-600">Atividades</p>
+      <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">
+        Registros de atividades
+      </h1>
+      <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600">
+        Esta área já exige uma sessão válida. O registro de data, horários,
+        duração e descrição das atividades será conectado aqui nas próximas
+        entregas.
+      </p>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-3">
+        {[
+          ["0h", "Horas registradas"],
+          ["0", "Atividades"],
+          ["—", "Último registro"],
+        ].map(([value, label]) => (
+          <div key={label} className="rounded-2xl bg-slate-50 p-5">
+            <p className="text-2xl font-bold text-slate-950">{value}</p>
+            <p className="mt-1 text-sm text-slate-500">{label}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+
+const cards = [
+  {
+    href: "/internships",
+    title: "Estágios",
+    description: "Cadastre e acompanhe seus estágios supervisionados.",
+  },
+  {
+    href: "/activities",
+    title: "Atividades",
+    description: "Registre atividades e acompanhe a evolução da carga horária.",
+  },
+  {
+    href: "/profile",
+    title: "Perfil",
+    description: "Confira seus dados acadêmicos e informações da conta.",
+  },
+] as const;
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-8">
+      <section>
+        <p className="text-sm font-semibold text-indigo-600">Área autenticada</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950 sm:text-4xl">
+          Visão geral
+        </h1>
+        <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600">
+          Este é o ponto de entrada da sua jornada de estágio no StageTrack.
+          Os próximos módulos vão transformar estes atalhos em acompanhamento
+          completo de estágio, horas e atividades.
+        </p>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {cards.map((card) => (
+          <Link
+            key={card.href}
+            href={card.href}
+            className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md"
+          >
+            <h2 className="text-lg font-bold text-slate-950">{card.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              {card.description}
+            </p>
+            <span className="mt-6 inline-flex text-sm font-semibold text-indigo-600">
+              Acessar →
+            </span>
+          </Link>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(protected)/internships/page.tsx
+++ b/src/app/(protected)/internships/page.tsx
@@ -1,0 +1,22 @@
+export default function InternshipsPage() {
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <p className="text-sm font-semibold text-indigo-600">Estágios</p>
+      <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">
+        Seus estágios supervisionados
+      </h1>
+      <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600">
+        A rota já está protegida e pronta para receber o cadastro e o
+        acompanhamento dos estágios nas próximas etapas do projeto.
+      </p>
+
+      <div className="mt-8 rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-6">
+        <p className="text-sm font-semibold text-slate-800">Nenhum estágio cadastrado ainda.</p>
+        <p className="mt-2 text-sm leading-6 text-slate-500">
+          O fluxo de criação do primeiro estágio será implementado no próximo
+          bloco funcional do StageTrack.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,0 +1,112 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { logoutAction } from "@/features/auth/actions/auth.actions";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+const navigation = [
+  { href: "/dashboard", label: "Visão geral" },
+  { href: "/internships", label: "Estágios" },
+  { href: "/activities", label: "Atividades" },
+  { href: "/profile", label: "Perfil" },
+] as const;
+
+function roleLabel(role: "student" | "advisor" | "coordinator" | undefined) {
+  switch (role) {
+    case "advisor":
+      return "Orientador";
+    case "coordinator":
+      return "Coordenador";
+    default:
+      return "Estudante";
+  }
+}
+
+export default async function ProtectedLayout({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  const supabase = await createClient();
+  const { data: claimsData, error } = await supabase.auth.getClaims();
+  const claims = claimsData?.claims;
+  const userId = claims?.sub;
+
+  if (error || !userId) {
+    redirect("/login");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name,role")
+    .eq("id", userId)
+    .maybeSingle();
+
+  const email = typeof claims.email === "string" ? claims.email : null;
+  const displayName = profile?.full_name ?? email ?? "Usuário StageTrack";
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-950">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-5 py-5 lg:flex-row lg:items-center lg:justify-between lg:px-8">
+          <div className="flex items-center justify-between gap-4">
+            <Link href="/dashboard" className="group">
+              <span className="block text-xs font-bold uppercase tracking-[0.24em] text-indigo-600">
+                StageTrack
+              </span>
+              <span className="mt-1 block text-sm font-medium text-slate-500 group-hover:text-slate-700">
+                Acompanhamento de estágio
+              </span>
+            </Link>
+
+            <form action={logoutAction} className="lg:hidden">
+              <button
+                type="submit"
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+              >
+                Sair
+              </button>
+            </form>
+          </div>
+
+          <nav aria-label="Navegação principal" className="overflow-x-auto">
+            <div className="flex min-w-max gap-1 rounded-2xl bg-slate-100 p-1">
+              {navigation.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="rounded-xl px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-white hover:text-slate-950"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </nav>
+
+          <div className="hidden items-center gap-4 lg:flex">
+            <div className="text-right">
+              <p className="max-w-52 truncate text-sm font-semibold text-slate-900">
+                {displayName}
+              </p>
+              <p className="text-xs text-slate-500">{roleLabel(profile?.role)}</p>
+            </div>
+
+            <form action={logoutAction}>
+              <button
+                type="submit"
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+              >
+                Sair
+              </button>
+            </form>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-7xl px-5 py-8 lg:px-8 lg:py-10">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -1,0 +1,74 @@
+import { getCurrentProfile } from "@/features/users";
+
+function roleLabel(role: "student" | "advisor" | "coordinator") {
+  switch (role) {
+    case "advisor":
+      return "Orientador";
+    case "coordinator":
+      return "Coordenador";
+    default:
+      return "Estudante";
+  }
+}
+
+export default async function ProfilePage() {
+  const result = await getCurrentProfile();
+
+  if (!result.ok || !result.data) {
+    return (
+      <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8">
+        <p className="text-sm font-semibold text-amber-800">Perfil indisponível</p>
+        <h1 className="mt-2 text-2xl font-bold text-amber-950">
+          Não foi possível carregar seus dados agora.
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-amber-800">
+          Sua sessão continua protegida. Tente novamente ao atualizar a página.
+        </p>
+      </section>
+    );
+  }
+
+  const profile = result.data;
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <p className="text-sm font-semibold text-indigo-600">Perfil</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">
+          Seus dados no StageTrack
+        </h1>
+        <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600">
+          Estas informações vêm do perfil protegido por RLS vinculado à sua
+          conta do Supabase Auth.
+        </p>
+      </section>
+
+      <section className="grid gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:grid-cols-2 sm:p-8">
+        <div className="rounded-2xl bg-slate-50 p-5">
+          <p className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            Nome completo
+          </p>
+          <p className="mt-2 font-semibold text-slate-950">{profile.full_name}</p>
+        </div>
+
+        <div className="rounded-2xl bg-slate-50 p-5">
+          <p className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            Papel
+          </p>
+          <p className="mt-2 font-semibold text-slate-950">
+            {roleLabel(profile.role)}
+          </p>
+        </div>
+
+        <div className="rounded-2xl bg-slate-50 p-5 sm:col-span-2">
+          <p className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            Matrícula
+          </p>
+          <p className="mt-2 font-semibold text-slate-950">
+            {profile.registration_number ?? "Ainda não informada"}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/features/auth/actions/auth.actions.ts
+++ b/src/features/auth/actions/auth.actions.ts
@@ -135,7 +135,7 @@ export async function loginAction(
     return profileError;
   }
 
-  redirect("/");
+  redirect("/dashboard");
 }
 
 export async function registerAction(
@@ -183,7 +183,7 @@ export async function registerAction(
     };
   }
 
-  redirect("/");
+  redirect("/dashboard");
 }
 
 export async function forgotPasswordAction(
@@ -236,4 +236,9 @@ export async function resetPasswordAction(
   }
 
   redirect("/login?message=password-updated");
+}
+
+export async function logoutAction() {
+  await logout();
+  redirect("/login");
 }

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -3,6 +3,55 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import type { Database } from "@/types/database";
 
+const PRIVATE_ROUTE_PREFIXES = [
+  "/dashboard",
+  "/internships",
+  "/activities",
+  "/profile",
+] as const;
+
+const AUTH_ENTRY_ROUTES = ["/login", "/register", "/forgot-password"] as const;
+
+function matchesRoute(pathname: string, route: string) {
+  return pathname === route || pathname.startsWith(`${route}/`);
+}
+
+function isPrivateRoute(pathname: string) {
+  return PRIVATE_ROUTE_PREFIXES.some((route) => matchesRoute(pathname, route));
+}
+
+function isAuthEntryRoute(pathname: string) {
+  return AUTH_ENTRY_ROUTES.some((route) => matchesRoute(pathname, route));
+}
+
+function copySessionState(source: NextResponse, target: NextResponse) {
+  source.cookies.getAll().forEach(({ name, value, ...options }) => {
+    target.cookies.set(name, value, options);
+  });
+
+  for (const header of ["cache-control", "expires", "pragma"] as const) {
+    const value = source.headers.get(header);
+
+    if (value) {
+      target.headers.set(header, value);
+    }
+  }
+
+  return target;
+}
+
+function redirectPreservingSession(
+  request: NextRequest,
+  sessionResponse: NextResponse,
+  pathname: string,
+) {
+  const url = request.nextUrl.clone();
+  url.pathname = pathname;
+  url.search = "";
+
+  return copySessionState(sessionResponse, NextResponse.redirect(url));
+}
+
 export async function updateSession(request: NextRequest) {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
@@ -38,7 +87,19 @@ export async function updateSession(request: NextRequest) {
     },
   });
 
-  await supabase.auth.getClaims();
+  // Keep this call immediately after client creation. getClaims validates the
+  // JWT and may refresh the cookie-backed session through @supabase/ssr.
+  const { data, error } = await supabase.auth.getClaims();
+  const isAuthenticated = !error && Boolean(data?.claims?.sub);
+  const pathname = request.nextUrl.pathname;
+
+  if (!isAuthenticated && isPrivateRoute(pathname)) {
+    return redirectPreservingSession(request, supabaseResponse, "/login");
+  }
+
+  if (isAuthenticated && isAuthEntryRoute(pathname)) {
+    return redirectPreservingSession(request, supabaseResponse, "/dashboard");
+  }
 
   return supabaseResponse;
 }


### PR DESCRIPTION
## Resumo

Implementa a STG-007 e estabelece a primeira área privada do StageTrack com proteção SSR em duas camadas.

### Rotas privadas
- `/dashboard`;
- `/internships`;
- `/activities`;
- `/profile`.

### Proteção
- Next.js Proxy valida identidade com `auth.getClaims()` antes das rotas privadas;
- visitante sem claims válidas é redirecionado para `/login`;
- usuário autenticado em `/login`, `/register` ou `/forgot-password` é enviado para `/dashboard`;
- `/reset-password` permanece acessível durante sessão de recuperação;
- redirects do Proxy preservam cookies renovados e headers de cache do `@supabase/ssr`;
- layout `(protected)` revalida `getClaims()` no servidor como segunda barreira;
- layout autenticado usa `dynamic = "force-dynamic"` para evitar ISR/cache compartilhável;
- `getSession()` não é usado para autorização.

### Experiência autenticada
- shell responsivo com navegação entre visão geral, estágios, atividades e perfil;
- dashboard privado inicial;
- `/profile` lê dados reais protegidos por RLS;
- `/internships` e `/activities` funcionam como entradas seguras para os próximos módulos;
- login e cadastro com sessão passam a entrar em `/dashboard`;
- logout por Server Action encerra a sessão e retorna para `/login`.

### Documentação
- `docs/AUTHENTICATION.md` atualizado com política de rotas, cache, redirects e defesa em profundidade.

### Validação final
- [x] `npm ci`;
- [x] `npm run lint`;
- [x] `npm run typecheck`;
- [x] `npm run build`.

Closes #7