### PR TITLE
feat: build authenticated application layout

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,18 +1,12 @@
 import type { ReactNode } from "react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
-import { logoutAction } from "@/features/auth/actions/auth.actions";
+import { AuthenticatedHeader } from "@/features/navigation/components/authenticated-header";
+import { MobileNavigation } from "@/features/navigation/components/mobile-navigation";
+import { Sidebar } from "@/features/navigation/components/sidebar";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
-
-const navigation = [
-  { href: "/dashboard", label: "Visão geral" },
-  { href: "/internships", label: "Estágios" },
-  { href: "/activities", label: "Atividades" },
-  { href: "/profile", label: "Perfil" },
-] as const;
 
 function roleLabel(role: "student" | "advisor" | "coordinator" | undefined) {
   switch (role) {
@@ -45,68 +39,28 @@ export default async function ProtectedLayout({
 
   const email = typeof claims.email === "string" ? claims.email : null;
   const displayName = profile?.full_name ?? email ?? "Usuário StageTrack";
+  const currentRoleLabel = roleLabel(profile?.role);
 
   return (
-    <div className="min-h-screen bg-slate-50 text-slate-950">
-      <header className="border-b border-slate-200 bg-white">
-        <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-5 py-5 lg:flex-row lg:items-center lg:justify-between lg:px-8">
-          <div className="flex items-center justify-between gap-4">
-            <Link href="/dashboard" className="group">
-              <span className="block text-xs font-bold uppercase tracking-[0.24em] text-indigo-600">
-                StageTrack
-              </span>
-              <span className="mt-1 block text-sm font-medium text-slate-500 group-hover:text-slate-700">
-                Acompanhamento de estágio
-              </span>
-            </Link>
+    <div className="flex min-h-screen bg-slate-50 text-slate-950">
+      <Sidebar
+        displayName={displayName}
+        roleLabel={currentRoleLabel}
+        email={email}
+      />
 
-            <form action={logoutAction} className="lg:hidden">
-              <button
-                type="submit"
-                className="rounded-xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-              >
-                Sair
-              </button>
-            </form>
-          </div>
+      <div className="min-w-0 flex-1">
+        <AuthenticatedHeader
+          displayName={displayName}
+          roleLabel={currentRoleLabel}
+        />
 
-          <nav aria-label="Navegação principal" className="overflow-x-auto">
-            <div className="flex min-w-max gap-1 rounded-2xl bg-slate-100 p-1">
-              {navigation.map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className="rounded-xl px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-white hover:text-slate-950"
-                >
-                  {item.label}
-                </Link>
-              ))}
-            </div>
-          </nav>
+        <main className="mx-auto w-full max-w-7xl px-5 py-7 pb-28 sm:px-6 sm:py-8 lg:px-8 lg:py-10 lg:pb-10">
+          {children}
+        </main>
+      </div>
 
-          <div className="hidden items-center gap-4 lg:flex">
-            <div className="text-right">
-              <p className="max-w-52 truncate text-sm font-semibold text-slate-900">
-                {displayName}
-              </p>
-              <p className="text-xs text-slate-500">{roleLabel(profile?.role)}</p>
-            </div>
-
-            <form action={logoutAction}>
-              <button
-                type="submit"
-                className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-              >
-                Sair
-              </button>
-            </form>
-          </div>
-        </div>
-      </header>
-
-      <main className="mx-auto w-full max-w-7xl px-5 py-8 lg:px-8 lg:py-10">
-        {children}
-      </main>
+      <MobileNavigation />
     </div>
   );
 }

--- a/src/features/navigation/components/authenticated-header.tsx
+++ b/src/features/navigation/components/authenticated-header.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { logoutAction } from "@/features/auth/actions/auth.actions";
+
+import { findActiveNavigationItem } from "../config/authenticated-navigation";
+
+type AuthenticatedHeaderProps = {
+  displayName: string;
+  roleLabel: string;
+};
+
+function initials(name: string) {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("") || "ST";
+}
+
+export function AuthenticatedHeader({
+  displayName,
+  roleLabel,
+}: AuthenticatedHeaderProps) {
+  const pathname = usePathname();
+  const activeItem = findActiveNavigationItem(pathname);
+
+  return (
+    <header className="sticky top-0 z-30 border-b border-slate-200/80 bg-white/90 backdrop-blur-xl">
+      <div className="flex min-h-18 items-center justify-between gap-4 px-5 py-3 sm:px-6 lg:min-h-20 lg:px-8">
+        <div className="flex min-w-0 items-center gap-3">
+          <Link
+            href="/dashboard"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-indigo-600 text-xs font-black text-white shadow-sm shadow-indigo-200 lg:hidden"
+            aria-label="Ir para o dashboard"
+          >
+            ST
+          </Link>
+
+          <div className="min-w-0">
+            <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-indigo-600">
+              {activeItem ? activeItem.label : "StageTrack"}
+            </p>
+            <h1 className="mt-0.5 truncate text-base font-bold tracking-tight text-slate-950 sm:text-lg">
+              {activeItem?.description ?? "Acompanhamento de estágio"}
+            </h1>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-3">
+          <div className="hidden items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 sm:flex lg:mr-1">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            Sessão protegida
+          </div>
+
+          <div className="hidden text-right xl:block">
+            <p className="max-w-44 truncate text-sm font-bold text-slate-900">
+              {displayName}
+            </p>
+            <p className="text-xs text-slate-500">{roleLabel}</p>
+          </div>
+
+          <span className="hidden h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-[11px] font-bold text-white xl:flex">
+            {initials(displayName)}
+          </span>
+
+          <form action={logoutAction} className="lg:hidden">
+            <button
+              type="submit"
+              className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs font-bold text-slate-600 transition hover:bg-slate-50 hover:text-slate-950"
+            >
+              Sair
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/features/navigation/components/mobile-navigation.tsx
+++ b/src/features/navigation/components/mobile-navigation.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import {
+  authenticatedNavigation,
+  isNavigationItemActive,
+} from "../config/authenticated-navigation";
+import { NavigationIcon } from "./navigation-icon";
+
+export function MobileNavigation() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Navegação principal mobile"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 px-2 pt-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-[0_-8px_30px_rgba(15,23,42,0.06)] backdrop-blur-xl lg:hidden"
+    >
+      <div className="mx-auto grid max-w-lg grid-cols-4 gap-1">
+        {authenticatedNavigation.map((item) => {
+          const active = isNavigationItemActive(pathname, item.href);
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={active ? "page" : undefined}
+              className={`flex min-w-0 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-bold transition ${
+                active
+                  ? "bg-indigo-50 text-indigo-700"
+                  : "text-slate-500 hover:bg-slate-50 hover:text-slate-900"
+              }`}
+            >
+              <NavigationIcon
+                name={item.icon}
+                className={`h-5 w-5 ${active ? "stroke-[2.2]" : ""}`}
+              />
+              <span className="max-w-full truncate">{item.mobileLabel}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/features/navigation/components/navigation-icon.tsx
+++ b/src/features/navigation/components/navigation-icon.tsx
@@ -1,0 +1,60 @@
+import type { NavigationIconName } from "../config/authenticated-navigation";
+
+type NavigationIconProps = {
+  name: NavigationIconName;
+  className?: string;
+};
+
+export function NavigationIcon({
+  name,
+  className = "h-5 w-5",
+}: NavigationIconProps) {
+  const common = {
+    className,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.8,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+  };
+
+  switch (name) {
+    case "internship":
+      return (
+        <svg {...common}>
+          <path d="M8 7V5.5A2.5 2.5 0 0 1 10.5 3h3A2.5 2.5 0 0 1 16 5.5V7" />
+          <path d="M4.5 7h15A1.5 1.5 0 0 1 21 8.5v9A2.5 2.5 0 0 1 18.5 20h-13A2.5 2.5 0 0 1 3 17.5v-9A1.5 1.5 0 0 1 4.5 7Z" />
+          <path d="M3 12.5c2.6 1.3 5.6 2 9 2s6.4-.7 9-2" />
+          <path d="M10 13.8h4" />
+        </svg>
+      );
+    case "activities":
+      return (
+        <svg {...common}>
+          <path d="M6 3.5h9l3 3V20a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4.5a1 1 0 0 1 1-1Z" />
+          <path d="M15 3.5V7h3.5" />
+          <path d="M8 11h7" />
+          <path d="M8 14.5h7" />
+          <path d="M8 18h4.5" />
+        </svg>
+      );
+    case "profile":
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="8" r="3.25" />
+          <path d="M5.5 20a6.5 6.5 0 0 1 13 0" />
+        </svg>
+      );
+    default:
+      return (
+        <svg {...common}>
+          <rect x="3.5" y="3.5" width="7" height="7" rx="1.5" />
+          <rect x="13.5" y="3.5" width="7" height="4.5" rx="1.5" />
+          <rect x="13.5" y="10.5" width="7" height="10" rx="1.5" />
+          <rect x="3.5" y="13" width="7" height="7.5" rx="1.5" />
+        </svg>
+      );
+  }
+}

--- a/src/features/navigation/components/sidebar.tsx
+++ b/src/features/navigation/components/sidebar.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { logoutAction } from "@/features/auth/actions/auth.actions";
+
+import {
+  authenticatedNavigation,
+  isNavigationItemActive,
+} from "../config/authenticated-navigation";
+import { NavigationIcon } from "./navigation-icon";
+
+type SidebarProps = {
+  displayName: string;
+  roleLabel: string;
+  email: string | null;
+};
+
+function initials(name: string) {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("") || "ST";
+}
+
+export function Sidebar({ displayName, roleLabel, email }: SidebarProps) {
+  const pathname = usePathname();
+
+  return (
+    <aside className="hidden h-screen w-72 shrink-0 border-r border-slate-200 bg-white lg:sticky lg:top-0 lg:flex lg:flex-col">
+      <div className="border-b border-slate-100 px-6 py-7">
+        <Link href="/dashboard" className="inline-flex items-center gap-3 group">
+          <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-indigo-600 text-sm font-black tracking-tight text-white shadow-sm shadow-indigo-200 transition group-hover:bg-indigo-500">
+            ST
+          </span>
+          <span>
+            <span className="block text-base font-black tracking-tight text-slate-950">
+              StageTrack
+            </span>
+            <span className="block text-xs font-medium text-slate-500">
+              Gestão de estágio
+            </span>
+          </span>
+        </Link>
+      </div>
+
+      <nav aria-label="Navegação principal" className="flex-1 px-4 py-6">
+        <p className="px-3 text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">
+          Navegação
+        </p>
+
+        <div className="mt-3 space-y-1.5">
+          {authenticatedNavigation.map((item) => {
+            const active = isNavigationItemActive(pathname, item.href);
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={active ? "page" : undefined}
+                className={`group flex items-center gap-3 rounded-2xl px-3 py-3 transition ${
+                  active
+                    ? "bg-indigo-50 text-indigo-700 shadow-sm ring-1 ring-inset ring-indigo-100"
+                    : "text-slate-600 hover:bg-slate-50 hover:text-slate-950"
+                }`}
+              >
+                <span
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition ${
+                    active
+                      ? "bg-white text-indigo-600 shadow-sm"
+                      : "bg-slate-50 text-slate-500 group-hover:bg-white group-hover:text-slate-700"
+                  }`}
+                >
+                  <NavigationIcon name={item.icon} />
+                </span>
+
+                <span className="min-w-0">
+                  <span className="block text-sm font-bold">{item.label}</span>
+                  <span
+                    className={`mt-0.5 block truncate text-xs ${
+                      active ? "text-indigo-500" : "text-slate-400"
+                    }`}
+                  >
+                    {item.description}
+                  </span>
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+
+      <div className="border-t border-slate-100 p-4">
+        <div className="rounded-2xl bg-slate-50 p-3.5">
+          <div className="flex items-center gap-3">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-900 text-xs font-bold text-white">
+              {initials(displayName)}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-bold text-slate-900">{displayName}</p>
+              <p className="truncate text-xs text-slate-500">
+                {roleLabel}{email ? ` · ${email}` : ""}
+              </p>
+            </div>
+          </div>
+
+          <form action={logoutAction} className="mt-3">
+            <button
+              type="submit"
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-100 hover:text-slate-950"
+            >
+              Sair da conta
+            </button>
+          </form>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/features/navigation/config/authenticated-navigation.ts
+++ b/src/features/navigation/config/authenticated-navigation.ts
@@ -1,0 +1,54 @@
+export type NavigationIconName =
+  | "dashboard"
+  | "internship"
+  | "activities"
+  | "profile";
+
+export type AuthenticatedNavigationItem = {
+  href: string;
+  label: string;
+  mobileLabel: string;
+  description: string;
+  icon: NavigationIconName;
+};
+
+export const authenticatedNavigation = [
+  {
+    href: "/dashboard",
+    label: "Dashboard",
+    mobileLabel: "Início",
+    description: "Visão geral do seu estágio",
+    icon: "dashboard",
+  },
+  {
+    href: "/internships",
+    label: "Meu Estágio",
+    mobileLabel: "Estágio",
+    description: "Dados e andamento do estágio",
+    icon: "internship",
+  },
+  {
+    href: "/activities",
+    label: "Atividades",
+    mobileLabel: "Atividades",
+    description: "Registros e carga horária",
+    icon: "activities",
+  },
+  {
+    href: "/profile",
+    label: "Perfil",
+    mobileLabel: "Perfil",
+    description: "Dados acadêmicos e da conta",
+    icon: "profile",
+  },
+] as const satisfies readonly AuthenticatedNavigationItem[];
+
+export function isNavigationItemActive(pathname: string, href: string) {
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function findActiveNavigationItem(pathname: string) {
+  return authenticatedNavigation.find((item) =>
+    isNavigationItemActive(pathname, item.href),
+  );
+}


### PR DESCRIPTION
## Resumo

Implementa a STG-008 refinando o shell seguro da STG-007 em uma navegação autenticada reutilizável e responsiva.

### Estrutura
- `Sidebar` dedicada para desktop;
- `AuthenticatedHeader` contextual;
- `MobileNavigation` fixa para telas pequenas;
- configuração única de navegação compartilhada por desktop/mobile;
- ícones internos sem nova dependência externa.

### Navegação
- Dashboard;
- Meu Estágio;
- Atividades;
- Perfil;
- rota atual destacada por `pathname`;
- subrotas também mantêm o item pai ativo, por exemplo `/internships/new` → Meu Estágio.

### Usuário
- nome, papel e e-mail continuam vindo do layout server-side;
- `user_metadata` não é usada para autorização;
- logout disponível no desktop e mobile;
- papel exibido a partir do perfil persistido no banco.

### Segurança preservada
- `auth.getClaims()` continua sendo validado no layout `(protected)`;
- `dynamic = "force-dynamic"` permanece no layout autenticado;
- componentes de navegação não duplicam lógica de sessão;
- Proxy e RLS não são alterados nesta issue.

### Validação final
- [x] `npm ci`;
- [x] `npm run lint`;
- [x] `npm run typecheck`;
- [x] `npm run build`.

Closes #8