### PR TITLE
feat: build dashboard placeholder states

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,55 +1,13 @@
-import Link from "next/link";
+import { DashboardOverview } from "@/features/dashboard/components/dashboard-overview";
+import type { DashboardViewModel } from "@/features/dashboard/types";
 
-const cards = [
-  {
-    href: "/internships",
-    title: "Estágios",
-    description: "Cadastre e acompanhe seus estágios supervisionados.",
-  },
-  {
-    href: "/activities",
-    title: "Atividades",
-    description: "Registre atividades e acompanhe a evolução da carga horária.",
-  },
-  {
-    href: "/profile",
-    title: "Perfil",
-    description: "Confira seus dados acadêmicos e informações da conta.",
-  },
-] as const;
+const emptyDashboard: DashboardViewModel = {
+  internship: null,
+  activityCount: 0,
+  lastActivityAt: null,
+  recentActivities: [],
+};
 
 export default function DashboardPage() {
-  return (
-    <div className="space-y-8">
-      <section>
-        <p className="text-sm font-semibold text-indigo-600">Área autenticada</p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950 sm:text-4xl">
-          Visão geral
-        </h1>
-        <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600">
-          Este é o ponto de entrada da sua jornada de estágio no StageTrack.
-          Os próximos módulos vão transformar estes atalhos em acompanhamento
-          completo de estágio, horas e atividades.
-        </p>
-      </section>
-
-      <section className="grid gap-4 md:grid-cols-3">
-        {cards.map((card) => (
-          <Link
-            key={card.href}
-            href={card.href}
-            className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md"
-          >
-            <h2 className="text-lg font-bold text-slate-950">{card.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-slate-600">
-              {card.description}
-            </p>
-            <span className="mt-6 inline-flex text-sm font-semibold text-indigo-600">
-              Acessar →
-            </span>
-          </Link>
-        ))}
-      </section>
-    </div>
-  );
+  return <DashboardOverview model={emptyDashboard} />;
 }

--- a/src/features/dashboard/components/dashboard-overview.tsx
+++ b/src/features/dashboard/components/dashboard-overview.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+
+import { formatDuration, formatShortDate } from "../formatters";
+import type { DashboardViewModel } from "../types";
+import { InternshipProgressCard } from "./internship-progress-card";
+import { MetricCard } from "./metric-card";
+import { RecentActivitiesCard } from "./recent-activities-card";
+
+type DashboardOverviewProps = {
+  model: DashboardViewModel;
+};
+
+export function DashboardOverview({ model }: DashboardOverviewProps) {
+  const internship = model.internship;
+  const remainingMinutes = internship
+    ? Math.max(0, internship.requiredMinutes - internship.completedMinutes)
+    : null;
+
+  return (
+    <div className="space-y-6 sm:space-y-8">
+      <section className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm font-bold text-indigo-600">Visão geral</p>
+          <h2 className="mt-2 max-w-3xl text-3xl font-black tracking-tight text-slate-950 sm:text-4xl">
+            Acompanhe seu estágio em um só lugar.
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base sm:leading-7">
+            Horas, atividades e progresso ficam organizados aqui conforme sua
+            jornada de estágio avança.
+          </p>
+        </div>
+
+        <Link
+          href="/internships"
+          className="inline-flex shrink-0 items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm shadow-indigo-200 transition hover:bg-indigo-500"
+        >
+          {internship ? "Ver Meu Estágio" : "Configurar Meu Estágio"}
+        </Link>
+      </section>
+
+      {!internship ? (
+        <section className="flex items-start gap-3 rounded-2xl border border-indigo-100 bg-indigo-50 px-4 py-3.5 text-sm leading-6 text-indigo-800">
+          <span
+            className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-indigo-600 shadow-sm"
+            aria-hidden="true"
+          >
+            i
+          </span>
+          <p>
+            Você ainda não possui um estágio cadastrado. Os indicadores abaixo
+            estão em estado inicial e serão preenchidos automaticamente quando
+            o acompanhamento começar.
+          </p>
+        </section>
+      ) : null}
+
+      <section aria-label="Indicadores do estágio" className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          label="Horas realizadas"
+          value={formatDuration(internship?.completedMinutes ?? 0)}
+          helper={
+            internship
+              ? "Somatório das atividades consideradas no acompanhamento."
+              : "Começará a contar após o primeiro registro."
+          }
+          accent="indigo"
+        />
+        <MetricCard
+          label="Horas restantes"
+          value={remainingMinutes === null ? "—" : formatDuration(remainingMinutes)}
+          helper={
+            internship
+              ? "Quanto falta para atingir a carga horária mínima."
+              : "Disponível após definir a carga horária do estágio."
+          }
+          accent="amber"
+        />
+        <MetricCard
+          label="Atividades"
+          value={String(model.activityCount)}
+          helper={
+            model.activityCount > 0
+              ? "Registros realizados neste acompanhamento."
+              : "Nenhuma atividade registrada até agora."
+          }
+          accent="emerald"
+        />
+        <MetricCard
+          label="Último registro"
+          value={formatShortDate(model.lastActivityAt)}
+          helper={
+            model.lastActivityAt
+              ? "Data da atividade mais recente."
+              : "Ainda não existe um registro de atividade."
+          }
+          accent="slate"
+        />
+      </section>
+
+      <InternshipProgressCard internship={internship} />
+
+      <RecentActivitiesCard
+        activities={model.recentActivities}
+        hasInternship={Boolean(internship)}
+      />
+    </div>
+  );
+}

--- a/src/features/dashboard/components/internship-progress-card.tsx
+++ b/src/features/dashboard/components/internship-progress-card.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+
+import { formatDuration, progressPercentage } from "../formatters";
+import type { DashboardInternshipSummary } from "../types";
+
+type InternshipProgressCardProps = {
+  internship: DashboardInternshipSummary | null;
+};
+
+export function InternshipProgressCard({
+  internship,
+}: InternshipProgressCardProps) {
+  if (!internship) {
+    return (
+      <section className="relative overflow-hidden rounded-3xl border border-slate-200 bg-slate-950 p-6 text-white shadow-sm sm:p-8">
+        <div
+          className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-indigo-500/20 blur-3xl"
+          aria-hidden="true"
+        />
+        <div
+          className="absolute -bottom-24 right-20 h-48 w-48 rounded-full bg-sky-400/10 blur-3xl"
+          aria-hidden="true"
+        />
+
+        <div className="relative max-w-2xl">
+          <span className="inline-flex rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] text-indigo-200">
+            Progresso do estágio
+          </span>
+
+          <h2 className="mt-5 text-2xl font-black tracking-tight sm:text-3xl">
+            Comece cadastrando seu estágio.
+          </h2>
+          <p className="mt-3 max-w-xl text-sm leading-6 text-slate-300 sm:text-base sm:leading-7">
+            Assim que um estágio estiver ativo, o StageTrack mostrará aqui a
+            carga horária realizada, o que falta cumprir e o avanço percentual.
+          </p>
+
+          <div className="mt-7">
+            <div className="flex items-center justify-between text-xs font-semibold text-slate-400">
+              <span>Horas concluídas</span>
+              <span>0%</span>
+            </div>
+            <div className="mt-2 h-2 overflow-hidden rounded-full bg-white/10">
+              <div className="h-full w-0 rounded-full bg-indigo-400" />
+            </div>
+          </div>
+
+          <Link
+            href="/internships"
+            className="mt-7 inline-flex items-center justify-center rounded-xl bg-white px-4 py-2.5 text-sm font-bold text-slate-950 transition hover:bg-indigo-50"
+          >
+            Ir para Meu Estágio
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  const progress = progressPercentage(
+    internship.completedMinutes,
+    internship.requiredMinutes,
+  );
+  const remainingMinutes = Math.max(
+    0,
+    internship.requiredMinutes - internship.completedMinutes,
+  );
+
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-slate-950 p-6 text-white shadow-sm sm:p-8">
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <span className="text-xs font-bold uppercase tracking-[0.16em] text-indigo-300">
+            Progresso do estágio
+          </span>
+          <h2 className="mt-2 text-2xl font-black tracking-tight">
+            {internship.title}
+          </h2>
+          <p className="mt-1 text-sm text-slate-400">
+            {internship.organizationName}
+          </p>
+        </div>
+
+        <div className="rounded-2xl bg-white/5 px-4 py-3 sm:text-right">
+          <p className="text-2xl font-black">{Math.round(progress)}%</p>
+          <p className="text-xs text-slate-400">concluído</p>
+        </div>
+      </div>
+
+      <div className="mt-7 h-2.5 overflow-hidden rounded-full bg-white/10">
+        <div
+          className="h-full rounded-full bg-indigo-400"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        <div className="rounded-2xl bg-white/5 p-4">
+          <p className="text-xs text-slate-400">Realizadas</p>
+          <p className="mt-1 text-lg font-bold">
+            {formatDuration(internship.completedMinutes)}
+          </p>
+        </div>
+        <div className="rounded-2xl bg-white/5 p-4">
+          <p className="text-xs text-slate-400">Restantes</p>
+          <p className="mt-1 text-lg font-bold">{formatDuration(remainingMinutes)}</p>
+        </div>
+        <div className="rounded-2xl bg-white/5 p-4">
+          <p className="text-xs text-slate-400">Carga mínima</p>
+          <p className="mt-1 text-lg font-bold">
+            {formatDuration(internship.requiredMinutes)}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/dashboard/components/metric-card.tsx
+++ b/src/features/dashboard/components/metric-card.tsx
@@ -1,0 +1,35 @@
+type MetricCardProps = {
+  label: string;
+  value: string;
+  helper: string;
+  accent: "indigo" | "emerald" | "amber" | "slate";
+};
+
+const accentClasses = {
+  indigo: "bg-indigo-50 text-indigo-700 ring-indigo-100",
+  emerald: "bg-emerald-50 text-emerald-700 ring-emerald-100",
+  amber: "bg-amber-50 text-amber-700 ring-amber-100",
+  slate: "bg-slate-100 text-slate-700 ring-slate-200",
+} as const;
+
+export function MetricCard({ label, value, helper, accent }: MetricCardProps) {
+  return (
+    <article className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold text-slate-500">{label}</p>
+          <p className="mt-3 text-3xl font-black tracking-tight text-slate-950 sm:text-4xl">
+            {value}
+          </p>
+        </div>
+
+        <span
+          className={`mt-0.5 h-3 w-3 rounded-full ring-4 ${accentClasses[accent]}`}
+          aria-hidden="true"
+        />
+      </div>
+
+      <p className="mt-4 text-xs leading-5 text-slate-400">{helper}</p>
+    </article>
+  );
+}

--- a/src/features/dashboard/components/metric-card.tsx
+++ b/src/features/dashboard/components/metric-card.tsx
@@ -6,10 +6,10 @@ type MetricCardProps = {
 };
 
 const accentClasses = {
-  indigo: "bg-indigo-50 text-indigo-700 ring-indigo-100",
-  emerald: "bg-emerald-50 text-emerald-700 ring-emerald-100",
-  amber: "bg-amber-50 text-amber-700 ring-amber-100",
-  slate: "bg-slate-100 text-slate-700 ring-slate-200",
+  indigo: "bg-indigo-500 ring-indigo-100",
+  emerald: "bg-emerald-500 ring-emerald-100",
+  amber: "bg-amber-500 ring-amber-100",
+  slate: "bg-slate-500 ring-slate-200",
 } as const;
 
 export function MetricCard({ label, value, helper, accent }: MetricCardProps) {

--- a/src/features/dashboard/components/recent-activities-card.tsx
+++ b/src/features/dashboard/components/recent-activities-card.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+
+import { formatDuration, formatShortDate } from "../formatters";
+import type { DashboardActivitySummary } from "../types";
+
+type RecentActivitiesCardProps = {
+  activities: DashboardActivitySummary[];
+  hasInternship: boolean;
+};
+
+const statusLabel = {
+  draft: "Rascunho",
+  submitted: "Enviada",
+  approved: "Aprovada",
+  rejected: "Correção necessária",
+} as const;
+
+const statusClasses = {
+  draft: "bg-slate-100 text-slate-600",
+  submitted: "bg-amber-50 text-amber-700",
+  approved: "bg-emerald-50 text-emerald-700",
+  rejected: "bg-rose-50 text-rose-700",
+} as const;
+
+export function RecentActivitiesCard({
+  activities,
+  hasInternship,
+}: RecentActivitiesCardProps) {
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between gap-4 border-b border-slate-100 px-5 py-5 sm:px-6">
+        <div>
+          <h2 className="text-lg font-black tracking-tight text-slate-950">
+            Atividades recentes
+          </h2>
+          <p className="mt-1 text-sm text-slate-500">
+            Seus últimos registros de estágio.
+          </p>
+        </div>
+
+        <Link
+          href="/activities"
+          className="shrink-0 text-sm font-bold text-indigo-600 transition hover:text-indigo-500"
+        >
+          Ver todas
+        </Link>
+      </div>
+
+      {activities.length === 0 ? (
+        <div className="px-5 py-10 text-center sm:px-6 sm:py-12">
+          <span
+            className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100 text-xl text-slate-400"
+            aria-hidden="true"
+          >
+            ≡
+          </span>
+          <h3 className="mt-4 text-base font-bold text-slate-900">
+            {hasInternship
+              ? "Nenhuma atividade registrada"
+              : "As atividades aparecerão aqui"}
+          </h3>
+          <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-slate-500">
+            {hasInternship
+              ? "Quando você registrar uma atividade, ela entrará automaticamente neste histórico recente."
+              : "Primeiro cadastre seu estágio. Depois, cada registro de atividade será resumido nesta seção."}
+          </p>
+          <Link
+            href={hasInternship ? "/activities" : "/internships"}
+            className="mt-5 inline-flex rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:bg-slate-50 hover:text-slate-950"
+          >
+            {hasInternship ? "Registrar atividade" : "Ir para Meu Estágio"}
+          </Link>
+        </div>
+      ) : (
+        <div className="divide-y divide-slate-100">
+          {activities.map((activity) => (
+            <article
+              key={activity.id}
+              className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6"
+            >
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-bold text-slate-900">
+                    {formatShortDate(activity.date)}
+                  </p>
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-[11px] font-bold ${statusClasses[activity.status]}`}
+                  >
+                    {statusLabel[activity.status]}
+                  </span>
+                </div>
+                <p className="mt-1 line-clamp-2 text-sm leading-6 text-slate-500">
+                  {activity.description}
+                </p>
+              </div>
+
+              <span className="shrink-0 rounded-xl bg-slate-100 px-3 py-2 text-sm font-bold text-slate-700">
+                {formatDuration(activity.durationMinutes)}
+              </span>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/dashboard/formatters.ts
+++ b/src/features/dashboard/formatters.ts
@@ -1,0 +1,42 @@
+export function formatDuration(minutes: number) {
+  const safeMinutes = Math.max(0, Math.round(minutes));
+  const hours = Math.floor(safeMinutes / 60);
+  const remainingMinutes = safeMinutes % 60;
+
+  if (hours === 0) {
+    return remainingMinutes === 0 ? "0h" : `${remainingMinutes}min`;
+  }
+
+  if (remainingMinutes === 0) {
+    return `${hours}h`;
+  }
+
+  return `${hours}h${String(remainingMinutes).padStart(2, "0")}`;
+}
+
+export function formatShortDate(isoDate: string | null) {
+  if (!isoDate) {
+    return "—";
+  }
+
+  const date = new Date(isoDate);
+
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+export function progressPercentage(completedMinutes: number, requiredMinutes: number) {
+  if (requiredMinutes <= 0) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, (completedMinutes / requiredMinutes) * 100));
+}

--- a/src/features/dashboard/types.ts
+++ b/src/features/dashboard/types.ts
@@ -1,0 +1,23 @@
+export type DashboardInternshipSummary = {
+  id: string;
+  title: string;
+  organizationName: string;
+  completedMinutes: number;
+  requiredMinutes: number;
+  expectedEndDate: string | null;
+};
+
+export type DashboardActivitySummary = {
+  id: string;
+  date: string;
+  description: string;
+  durationMinutes: number;
+  status: "draft" | "submitted" | "approved" | "rejected";
+};
+
+export type DashboardViewModel = {
+  internship: DashboardInternshipSummary | null;
+  activityCount: number;
+  lastActivityAt: string | null;
+  recentActivities: DashboardActivitySummary[];
+};


### PR DESCRIPTION
## Resumo

Implementa a STG-009 com a primeira estrutura visual definitiva do `/dashboard`, sem apresentar dados fictícios como métricas reais.

### Estrutura
- cards de horas realizadas, horas restantes, atividades e último registro;
- bloco principal de progresso do estágio;
- seção de atividades recentes;
- CTA para configurar/acessar Meu Estágio;
- estado explícito sem estágio;
- estado explícito sem registros.

### Arquitetura
- `DashboardViewModel` tipado para desacoplar UI da futura camada de dados;
- componentes de métrica, progresso e atividades recentes reutilizáveis;
- formatadores de duração, data e percentual centralizados;
- a página atual injeta um modelo vazio e poderá trocar essa fonte por queries reais sem reescrever a apresentação.

### Dados
- nenhum estágio fictício é exibido;
- horas realizadas começam em `0h`;
- horas restantes e último registro ficam `—` enquanto não houver contexto suficiente;
- atividades começam em `0`;
- a interface explica por que os indicadores ainda estão vazios.

### Validação final
- [x] `npm ci`;
- [x] `npm run lint`;
- [x] `npm run typecheck`;
- [x] `npm run build`.

Closes #9