### PR TITLE
docs: close foundation sprint and align roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ O StageTrack centraliza a jornada acadêmica de estágio em um único ambiente: 
 
 ## Objetivo
 
-Reduzir controles manuais e fragmentados, oferecendo ao estudante uma forma simples de registrar atividades e acompanhar sua carga horária, enquanto prepara a base para acompanhamento acadêmico institucional.
+Reduzir controles manuais e fragmentados, oferecendo ao estudante uma forma simples de registrar atividades e acompanhar sua carga horária, enquanto prepara uma base relacional e segura para acompanhamento acadêmico institucional.
 
 ## MVP do aluno
 
-O primeiro marco do produto permitirá que um estudante:
+O primeiro grande marco do produto permitirá que um estudante:
 
 1. crie uma conta e faça login;
 2. cadastre seu estágio;
@@ -18,23 +18,94 @@ O primeiro marco do produto permitirá que um estudante:
 4. acompanhe horas cumpridas e restantes;
 5. consulte o histórico de registros.
 
-## Stack planejada
+Esse marco será considerado o **StageTrack Student MVP**.
 
-- Next.js
+## Stack atual
+
+- Next.js App Router
+- React
 - TypeScript
 - Tailwind CSS
+- Zod
 - PostgreSQL (Supabase)
 - Supabase Auth
-- Supabase Storage
+- `@supabase/ssr`
 - Row Level Security (RLS)
-- Zod
-- React Hook Form
-- Vercel
+- GitHub Actions
+- Vercel como plataforma de hospedagem planejada
 
-## Status
+Supabase Storage será incorporado quando o módulo de documentos entrar no roadmap.
 
-🚧 Em desenvolvimento — fase de fundação e definição do MVP.
+## Estado atual
+
+### Fundação de engenharia — concluída
+
+A Sprint 0 já entregou:
+
+- aplicação Next.js estruturada por domínio;
+- autenticação com Supabase Auth;
+- sessões SSR baseadas em cookies;
+- cadastro, login, logout e recuperação de senha;
+- perfil persistido em PostgreSQL;
+- RLS e grants de menor privilégio para o perfil;
+- proteção de rotas privadas com Proxy + validação server-side;
+- layout autenticado responsivo;
+- dashboard estrutural com estados vazios;
+- migrations versionadas;
+- tipos TypeScript gerados do banco;
+- CI com `npm ci`, lint, typecheck e build.
+
+### Sprint 1 — Internship Foundation
+
+O desenvolvimento entra agora no núcleo funcional do produto:
+
+```text
+Catálogo acadêmico
+   ↓
+Concedentes e supervisores
+   ↓
+Modelo de estágio + RLS
+   ↓
+Repository
+   ↓
+Cadastro do estágio
+   ↓
+Meu Estágio
+   ↓
+Dashboard com dados reais
+```
+
+### Deploy
+
+O primeiro projeto hospedado do StageTrack na Vercel ainda é uma pendência explícita do backlog (`STG-020`). O código já passa pelo build de produção na CI, mas a aplicação não deve ser considerada publicada até a conclusão dessa etapa.
+
+## Segurança
+
+A interface não é tratada como barreira de autorização.
+
+- identidade server-side é validada com `auth.getClaims()`;
+- dados expostos pela Data API usam Row Level Security;
+- o usuário não pode promover o próprio papel (`student`, `advisor`, `coordinator`);
+- chaves privilegiadas do Supabase não são expostas no navegador;
+- mudanças de schema e políticas são versionadas em `supabase/migrations`.
+
+## Qualidade
+
+Pull requests relevantes devem passar por:
+
+```text
+npm ci
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Testes automatizados serão adicionados progressivamente, priorizando regras de negócio, cálculos e autorização.
 
 ## Documentação
 
-A documentação de produto e arquitetura fica em [`/docs`](./docs).
+- [`docs/PRODUCT_VISION.md`](./docs/PRODUCT_VISION.md) — visão de produto;
+- [`docs/REQUIREMENTS.md`](./docs/REQUIREMENTS.md) — requisitos e regras de negócio;
+- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — decisões técnicas e estrutura;
+- [`docs/AUTHENTICATION.md`](./docs/AUTHENTICATION.md) — autenticação, sessão e proteção de rotas;
+- [`docs/ROADMAP.md`](./docs/ROADMAP.md) — evolução por sprints.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,34 +1,40 @@
-# StageTrack — Arquitetura Inicial
+# StageTrack — Arquitetura
 
-## Stack
+## Stack atual
 
-- Next.js
+- Next.js App Router
+- React
 - TypeScript
 - Tailwind CSS
-- React Hook Form
 - Zod
 - PostgreSQL (Supabase)
 - Supabase Auth
-- Supabase Storage
+- `@supabase/ssr`
 - Row Level Security (RLS)
-- Vercel
+- GitHub Actions
+- Vercel como plataforma de hospedagem planejada
+
+Supabase Storage entra quando o módulo de documentos for implementado. Bibliotecas adicionais de formulários só serão incorporadas se a complexidade dos próximos fluxos justificar a dependência; os fluxos atuais usam Server Actions e recursos nativos do React.
 
 ## Estratégia
 
-O StageTrack será inicialmente uma aplicação web responsiva em um único projeto Next.js. O Supabase fornecerá PostgreSQL, autenticação, armazenamento de arquivos e APIs de acesso aos dados. O MVP não terá um backend separado.
+O StageTrack é uma aplicação web responsiva em um único projeto Next.js. O Supabase fornece PostgreSQL, autenticação e Data API. O MVP não possui um backend separado.
 
 ```text
-Next.js
+Browser
    ↓
-Supabase SDK / SSR
-   ├── Auth
-   ├── PostgreSQL
-   └── Storage
+Next.js App Router
+   ├── Server Components / Server Actions
+   └── Client Components quando necessário
+          ↓
+      Supabase SSR / SDK
+          ├── Auth
+          └── PostgreSQL + RLS
 ```
 
-O domínio é fortemente relacional. PostgreSQL será usado para representar relações entre alunos, cursos, estágios, instituições, supervisores, orientadores, atividades e documentos com foreign keys e constraints.
+O domínio é fortemente relacional. PostgreSQL representa relações entre alunos, cursos, estágios, instituições, supervisores, orientadores, atividades e documentos com foreign keys, constraints e índices.
 
-## Estrutura sugerida
+## Estrutura do repositório
 
 ```text
 stagetrack/
@@ -42,41 +48,44 @@ stagetrack/
 │   ├── app/
 │   ├── components/
 │   ├── features/
-│   ├── hooks/
 │   ├── lib/
 │   │   └── supabase/
-│   ├── schemas/
-│   ├── services/
-│   ├── types/
-│   └── utils/
+│   └── types/
 ├── .env.example
 └── README.md
 ```
 
 ## Organização por domínio
 
+A aplicação evita concentrar regras em componentes de página. Funcionalidades são agrupadas por domínio:
+
 ```text
 src/features/
 ├── auth/
 ├── users/
-├── internships/
-├── internship-types/
-├── organizations/
-├── supervisors/
-└── activities/
+├── navigation/
+├── dashboard/
+├── internships/       # Sprint 1
+├── internship-types/  # Sprint 1
+├── organizations/     # Sprint 1
+├── supervisors/       # Sprint 1
+└── activities/        # Sprint 2
 ```
 
-Cada domínio poderá conter seus próprios `components`, `services`, `schemas`, `types`, `hooks` e `utils` quando necessário.
+Cada domínio pode conter `components`, `repositories`, `services`, `schemas`, `types`, `config` e utilitários conforme necessidade real.
 
 ## Acesso a dados
 
-Chamadas ao Supabase não devem ficar espalhadas pela interface. Serviços/repositories concentrarão operações de domínio.
+Chamadas ao Supabase não devem ficar espalhadas pela interface. Repositories concentram operações de domínio.
+
+Exemplo de direção para Sprint 1/2:
 
 ```text
 internshipRepository
 - createInternship()
 - getInternship()
 - getStudentInternships()
+- getCurrentInternship()
 - updateInternship()
 
 activityRepository
@@ -86,63 +95,79 @@ activityRepository
 - getInternshipActivities()
 ```
 
-A autorização não dependerá desses repositories: o PostgreSQL também aplicará RLS para impedir acesso indevido mesmo em chamadas diretas à Data API.
+A autorização nunca dependerá apenas desses repositories: o PostgreSQL também aplica RLS para impedir acesso indevido mesmo em chamadas diretas à Data API.
 
-## Tabelas iniciais
+## Estado atual do banco
+
+### `profiles`
+
+Implementada e ligada 1:1 ao Supabase Auth:
 
 ```text
-profiles
+id                  UUID PK / FK auth.users.id
+full_name           text
+role                app_role
+registration_number text nullable
+created_at          timestamptz
+updated_at          timestamptz
+```
+
+Papéis disponíveis:
+
+```text
+student
+advisor
+coordinator
+```
+
+O usuário não possui privilégio para promover o próprio `role`.
+
+## Schema planejado para Sprint 1
+
+A Sprint 1 adicionará de forma incremental:
+
+```text
+academic_institutions
 courses
 internship_types
 organizations
 supervisors
 internships
-activity_logs
 ```
 
-Tabelas futuras:
+`profiles.course_id` será adicionado quando `courses` existir.
+
+Tabelas posteriores:
 
 ```text
-documents
-notifications
-audit_logs
+activity_logs  # Sprint 2
+documents      # Sprint 4
+notifications  # pós-MVP / quando necessário
+audit_logs     # evolução institucional
 ```
 
-## Relações principais
+## Relações-alvo do núcleo
 
 ```text
 auth.users
     │
     └── profiles
           │
-          ├── courses
+          ├── course
+          │     └── academic_institution
           │
           └── internships
-                ├── internship_types
-                ├── organizations
+                ├── internship_type
+                ├── organization
                 │     └── supervisors
-                ├── advisor (profiles)
-                ├── activity_logs
-                └── documents
+                ├── advisor (profiles, futuro)
+                ├── activity_logs (Sprint 2)
+                └── documents (Sprint 4)
 ```
 
-IDs de domínio utilizarão UUIDs. Relações serão protegidas por foreign keys sempre que aplicável.
+IDs de domínio utilizam UUIDs. Relações devem ser protegidas por foreign keys sempre que aplicável.
 
-## Modelos principais
-
-### Profile
-
-```text
-id (FK auth.users.id)
-name
-role
-course_id
-registration_number
-created_at
-updated_at
-```
-
-### Internship
+## Modelo-alvo de estágio
 
 ```text
 id
@@ -159,7 +184,19 @@ created_at
 updated_at
 ```
 
-### ActivityLog
+Status previstos:
+
+```text
+draft
+active
+paused
+completed
+cancelled
+```
+
+`required_minutes` será um snapshot da modalidade selecionada para preservar o histórico caso a configuração acadêmica seja alterada no futuro.
+
+## Modelo-alvo de atividade
 
 ```text
 id
@@ -181,19 +218,17 @@ updated_at
 
 ## Tempo e carga horária
 
-A fonte de verdade para duração será `duration_minutes`, nunca horas decimais.
+A fonte de verdade para duração é minuto inteiro, nunca hora decimal.
 
 ```text
 13:00 → 17:30 = 270 minutos
 ```
 
-Horas cumpridas, horas restantes e percentual serão valores derivados dos registros. Constraints e validações de aplicação devem impedir durações inválidas.
+Horas cumpridas, horas restantes e percentual são valores derivados dos registros. Constraints e validações de aplicação devem impedir durações inválidas.
 
-## Autenticação
+## Autenticação e sessão
 
-Supabase Auth será responsável por cadastro, login, logout, recuperação de senha e sessão.
-
-O usuário autenticado existe em `auth.users`. Dados acadêmicos e de perfil ficarão em `public.profiles`, usando o mesmo UUID:
+Supabase Auth é responsável por cadastro, login, logout, recuperação de senha e sessão.
 
 ```text
 Supabase Auth
@@ -203,22 +238,48 @@ auth.users.id
 public.profiles.id
 ```
 
-## Segurança
+O cliente Supabase server-side é criado por requisição. `cookies()` é lido antes do uso do cliente para manter o contexto request-bound no Next.js.
 
-A interface não será considerada uma barreira de segurança.
+### Proteção de rotas
 
-As tabelas expostas pela Data API utilizarão Row Level Security. Políticas iniciais seguirão o princípio de menor privilégio:
+A proteção usa duas camadas:
 
-- aluno acessa apenas os próprios dados;
-- orientador acessa apenas estudantes vinculados quando essa função existir;
-- coordenação acessa apenas seu contexto institucional;
-- operações administrativas não usam chaves privilegiadas no navegador.
+```text
+Request
+  ↓
+Next.js Proxy + auth.getClaims()
+  ↓
+layout (protected) + auth.getClaims()
+  ↓
+Página privada
+```
 
-A `service_role`/secret key nunca deverá ser exposta em variáveis `NEXT_PUBLIC_*`.
+`auth.getSession()` não é usado como prova de identidade no servidor.
+
+Rotas autenticadas são `force-dynamic` para evitar ISR/cache compartilhado de conteúdo dependente de sessão.
+
+Detalhes adicionais ficam em [`AUTHENTICATION.md`](./AUTHENTICATION.md).
+
+## Segurança de dados
+
+A interface não é considerada uma barreira de segurança.
+
+Tabelas expostas pela Data API utilizam Row Level Security e grants mínimos.
+
+Princípios:
+
+- aluno acessa apenas os próprios dados quando a entidade é pessoal;
+- dados de catálogo terão leitura controlada e mutação administrativa;
+- orientador acessará apenas estudantes vinculados quando essa função existir;
+- coordenação acessará apenas seu contexto institucional quando essa função existir;
+- operações administrativas não usam chaves privilegiadas no navegador;
+- `service_role`/secret keys nunca entram em variáveis `NEXT_PUBLIC_*`.
+
+Após alterações DDL, security e performance advisors do Supabase devem ser revisados.
 
 ## Migrations
 
-Mudanças de schema deverão ser versionadas em `supabase/migrations`.
+Mudanças de schema são versionadas em `supabase/migrations`.
 
 Isso inclui:
 
@@ -226,12 +287,14 @@ Isso inclui:
 - foreign keys;
 - constraints;
 - índices;
-- funções/triggers quando necessários;
+- enums;
+- funções/triggers;
+- grants;
 - políticas RLS.
 
 Evitar alterações manuais no banco que não sejam reproduzíveis por migration.
 
-## Rotas iniciais
+## Rotas
 
 Públicas:
 
@@ -240,6 +303,9 @@ Públicas:
 /login
 /register
 /forgot-password
+/reset-password
+/auth/callback
+/auth/confirm
 ```
 
 Privadas:
@@ -252,14 +318,19 @@ Privadas:
 /profile
 ```
 
+## Dashboard
+
+O dashboard já possui um `DashboardViewModel` desacoplado da fonte de dados. Enquanto não existe estágio persistido, a página utiliza um modelo vazio honesto. Na STG-019, a fonte será substituída por queries reais sem reescrever os componentes visuais.
+
 ## Qualidade
 
 Antes de mergear funcionalidades relevantes:
 
 ```text
-lint
-typecheck
-build
+npm ci
+npm run lint
+npm run typecheck
+npm run build
 ```
 
 Testes automatizados serão adicionados progressivamente, priorizando cálculos, regras, autorização e fluxos críticos.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,64 +1,164 @@
-# StageTrack — Roadmap Inicial
+# StageTrack — Roadmap
 
 ## Objetivo do roadmap
 
-Evoluir o StageTrack em ciclos pequenos, priorizando um primeiro produto realmente utilizável por estudantes antes de adicionar recursos institucionais mais complexos.
+Evoluir o StageTrack em ciclos pequenos e verificáveis, priorizando um primeiro produto realmente utilizável por estudantes antes de adicionar recursos institucionais mais complexos.
+
+Cada etapa relevante deve preservar três princípios:
+
+1. regras de negócio explícitas;
+2. autorização também aplicada no PostgreSQL com RLS;
+3. mudanças pequenas, versionadas e validadas pela CI.
+
+---
 
 ## Sprint 0 — Foundation
 
-Objetivo: preparar a base técnica do produto.
+**Status da engenharia: concluída.**
 
-- inicializar aplicação Next.js;
-- estruturar diretórios;
-- configurar Firebase;
-- implementar fundação de autenticação;
-- criar modelo de usuário;
-- criar telas de login, cadastro e recuperação;
-- proteger rotas privadas;
-- criar layout autenticado;
-- criar dashboard placeholder;
-- adicionar regras iniciais do Firestore;
-- consolidar documentação;
-- configurar CI com lint, typecheck e build.
+Objetivo: preparar uma fundação técnica segura e reutilizável para o produto.
 
-### Definition of Done
+### Entregue
 
-A Sprint 0 estará concluída quando:
+- [x] aplicação Next.js App Router;
+- [x] estrutura por domínio;
+- [x] PostgreSQL no Supabase;
+- [x] Supabase Auth;
+- [x] sessão SSR com `@supabase/ssr`;
+- [x] cadastro, login, logout e recuperação de senha;
+- [x] tabela `profiles` ligada a `auth.users`;
+- [x] papéis `student`, `advisor` e `coordinator`;
+- [x] RLS e grants de menor privilégio para perfis;
+- [x] migrations versionadas;
+- [x] tipos TypeScript gerados do schema real;
+- [x] Proxy de renovação/validação de sessão;
+- [x] proteção server-side das rotas privadas;
+- [x] layout autenticado responsivo;
+- [x] navegação desktop/mobile com rota ativa;
+- [x] dashboard estrutural com estados vazios;
+- [x] documentação-base;
+- [x] CI com `npm ci`, lint, typecheck e build.
 
-- aplicação rodar localmente;
-- build passar;
-- deploy inicial existir;
-- Firebase estiver conectado;
-- cadastro e login funcionarem;
-- dashboard exigir autenticação;
-- regras básicas do Firestore existirem;
-- documentação estiver versionada;
-- CI estiver executando com sucesso.
+### Definition of Done de engenharia
+
+A fundação é considerada pronta porque:
+
+- o build de produção passa de forma reproduzível;
+- cadastro e login possuem implementação completa;
+- conteúdo privado exige claims válidas;
+- perfil possui persistência e autorização no banco;
+- alterações de schema são reproduzíveis por migration;
+- nenhuma chave privilegiada é necessária no navegador;
+- documentação e CI estão versionadas.
+
+### Release gate ainda pendente
+
+O StageTrack ainda não possui projeto hospedado na Vercel.
+
+A **STG-020 — Configurar deploy de desenvolvimento na Vercel** fecha essa pendência externa e será necessária antes da validação end-to-end dos fluxos da Sprint 1.
+
+---
 
 ## Sprint 1 — Internship Foundation
 
-Objetivo: permitir ao estudante cadastrar e visualizar seu estágio.
+**Status: em andamento.**
 
-- modalidades de estágio;
-- instituições;
-- cadastro do estágio;
-- visualização do estágio;
-- status do estágio;
-- dashboard com dados reais.
+Objetivo: permitir ao estudante cadastrar, visualizar e começar a acompanhar um estágio real.
+
+### Sequência planejada
+
+#### STG-013 — Catálogo acadêmico base
+
+- instituições de ensino;
+- cursos;
+- modalidades/componentes de estágio;
+- carga obrigatória em minutos;
+- vínculo de perfil com curso;
+- RLS de leitura do catálogo.
+
+#### STG-014 — Concedentes e supervisores
+
+- instituições concedentes;
+- supervisores;
+- integridade referencial;
+- políticas de acesso aos dados.
+
+#### STG-015 — Modelo de estágio e RLS
+
+- entidade `internships`;
+- status `draft`, `active`, `paused`, `completed`, `cancelled`;
+- vínculos com aluno, modalidade, concedente e supervisor;
+- snapshot protegido de carga obrigatória;
+- datas e constraints;
+- políticas RLS do aluno.
+
+#### STG-016 — Repository de estágios
+
+- criação;
+- leitura por ID;
+- listagem do histórico;
+- estágio atual;
+- atualização de campos autorizados.
+
+#### STG-017 — Cadastro do estágio
+
+- formulário responsivo;
+- catálogo acadêmico;
+- concedente e supervisor;
+- datas;
+- criação segura pelo repository.
+
+#### STG-018 — Meu Estágio
+
+- visualização do estágio atual;
+- status;
+- carga horária obrigatória;
+- organização e supervisor;
+- histórico e estados vazios.
+
+#### STG-019 — Dashboard com estágio real
+
+- substituir o `DashboardViewModel` vazio por dados persistidos;
+- carga mínima e horas restantes reais;
+- progresso inicial;
+- preservar o estado sem estágio.
+
+### Definition of Done
+
+A Sprint 1 estará concluída quando o estudante conseguir:
+
+```text
+Criar conta
+   ↓
+Entrar na área privada
+   ↓
+Cadastrar seu estágio
+   ↓
+Visualizar o estágio salvo
+   ↓
+Ver carga mínima e contexto real no dashboard
+```
+
+Ainda não haverá soma de horas realizadas porque essa responsabilidade começa na Sprint 2.
+
+---
 
 ## Sprint 2 — Activity Tracking
 
-Objetivo: tornar o StageTrack utilizável no dia a dia.
+Objetivo: tornar o StageTrack utilizável no dia a dia do estágio.
 
-- registro de atividades;
+- modelo `activity_logs`;
+- registro de data, início, fim e descrição;
 - cálculo automático de duração;
-- histórico de atividades;
+- armazenamento da duração em minutos;
+- histórico cronológico;
 - edição e exclusão conforme regras;
 - soma das horas;
 - horas restantes;
-- percentual de conclusão.
+- percentual de conclusão;
+- integração completa com o dashboard.
 
-### Primeiro grande marco
+### Primeiro grande marco — Student MVP
 
 Ao final da Sprint 2, o aluno deverá conseguir:
 
@@ -76,9 +176,12 @@ Visualizar progresso
 
 Esse marco será chamado de **StageTrack Student MVP**.
 
+---
+
 ## Sprint 3 — Academic Tracking
 
 - professor orientador;
+- vínculo aluno/orientador;
 - lista de orientandos;
 - envio de registros para análise;
 - aprovação e rejeição;
@@ -88,6 +191,7 @@ Esse marco será chamado de **StageTrack Student MVP**.
 ## Sprint 4 — Documents
 
 - documentos obrigatórios;
+- Supabase Storage;
 - upload;
 - status;
 - revisão;
@@ -106,7 +210,10 @@ Esse marco será chamado de **StageTrack Student MVP**.
 - filtros;
 - alunos em risco;
 - estágios ativos e concluídos;
-- modalidades e configurações por curso.
+- gestão de cursos e modalidades;
+- configurações por instituição.
+
+---
 
 ## Pós-1.0
 


### PR DESCRIPTION
## Resumo

Implementa a STG-012 e alinha a documentação ao estado real do StageTrack após a conclusão da fundação e a migração definitiva para Supabase/PostgreSQL.

### README
- stack atual, não apenas planejada;
- entregas reais da fundação;
- início da Sprint 1;
- segurança e quality gates;
- deploy Vercel explicitamente pendente via STG-020.

### Roadmap
- remove Firebase/Firestore como tecnologia vigente;
- marca a engenharia da Sprint 0 como concluída;
- separa o deploy como release gate externo;
- detalha STG-013–STG-019 como sequência da Internship Foundation;
- mantém Sprint 2 como marco do Student MVP.

### Arquitetura
- separa schema implementado de schema planejado;
- registra `profiles` real e RLS atual;
- documenta Proxy + layout server-side e `getClaims()`;
- registra `DashboardViewModel` e migrations;
- remove React Hook Form da stack atual, pois não é dependência do projeto neste momento.

### Validação final
- [x] `npm ci`;
- [x] `npm run lint`;
- [x] `npm run typecheck`;
- [x] `npm run build`.

Closes #25