### PR TITLE
feat: add internship repository

### DIFF
--- a/src/features/internships/index.ts
+++ b/src/features/internships/index.ts
@@ -1,0 +1,26 @@
+export {
+  createInternship,
+  getCurrentInternship,
+  getInternship,
+  listStudentInternships,
+  updateInternship,
+} from "./repositories/internship.repository";
+
+export {
+  createInternshipInputSchema,
+  internshipIdSchema,
+  studentInternshipStatusSchema,
+  updateInternshipInputSchema,
+} from "./schemas/internship.schema";
+
+export type {
+  CreateInternshipInput,
+  StudentInternshipStatus,
+  UpdateInternshipInput,
+} from "./schemas/internship.schema";
+export type {
+  Internship,
+  InternshipRepositoryError,
+  InternshipResult,
+  InternshipStatus,
+} from "./types";

--- a/src/features/internships/repositories/internship.repository.ts
+++ b/src/features/internships/repositories/internship.repository.ts
@@ -1,0 +1,238 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import { createClient } from "@/lib/supabase/server";
+import type { TablesInsert, TablesUpdate } from "@/types/database";
+
+import {
+  createInternshipInputSchema,
+  internshipIdSchema,
+  updateInternshipInputSchema,
+  type CreateInternshipInput,
+  type UpdateInternshipInput,
+} from "../schemas/internship.schema";
+import type { Internship, InternshipResult } from "../types";
+
+const INTERNSHIP_COLUMNS =
+  "id,student_id,internship_type_id,organization_id,supervisor_id,advisor_id,start_date,expected_end_date,required_minutes,status,created_at,updated_at" as const;
+
+function repositoryError(
+  code: string,
+  message: string,
+): InternshipResult<never> {
+  return { ok: false, error: { code, message } };
+}
+
+function databaseError(error: PostgrestError): InternshipResult<never> {
+  return repositoryError(error.code, error.message);
+}
+
+async function getAuthenticatedContext() {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+  const userId = data?.claims?.sub;
+
+  if (error || !userId) {
+    return {
+      ok: false as const,
+      error: {
+        code: error?.code ?? "not_authenticated",
+        message: error?.message ?? "Authenticated user is required.",
+      },
+    };
+  }
+
+  return { ok: true as const, supabase, userId };
+}
+
+export async function createInternship(
+  input: CreateInternshipInput,
+): Promise<InternshipResult<Internship>> {
+  const parsed = createInternshipInputSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return repositoryError(
+      "invalid_internship_input",
+      parsed.error.issues[0]?.message ?? "Invalid internship data.",
+    );
+  }
+
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const clientPayload = {
+    internship_type_id: parsed.data.internshipTypeId,
+    organization_id: parsed.data.organizationId,
+    supervisor_id: parsed.data.supervisorId ?? null,
+    start_date: parsed.data.startDate,
+    expected_end_date: parsed.data.expectedEndDate ?? null,
+  };
+
+  // `required_minutes` is NOT supplied by the client. PostgreSQL fills it in
+  // through the protected BEFORE INSERT trigger, while generated Supabase types
+  // cannot infer trigger-populated required columns.
+  const insertPayload =
+    clientPayload as unknown as TablesInsert<"internships">;
+
+  const { data, error } = await auth.supabase
+    .from("internships")
+    .insert(insertPayload)
+    .select(INTERNSHIP_COLUMNS)
+    .single();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function getInternship(
+  internshipId: string,
+): Promise<InternshipResult<Internship | null>> {
+  const parsedId = internshipIdSchema.safeParse(internshipId);
+
+  if (!parsedId.success) {
+    return repositoryError("invalid_internship_id", "Invalid internship ID.");
+  }
+
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("internships")
+    .select(INTERNSHIP_COLUMNS)
+    .eq("id", parsedId.data)
+    .eq("student_id", auth.userId)
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function listStudentInternships(): Promise<
+  InternshipResult<Internship[]>
+> {
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("internships")
+    .select(INTERNSHIP_COLUMNS)
+    .eq("student_id", auth.userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function getCurrentInternship(): Promise<
+  InternshipResult<Internship | null>
+> {
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("internships")
+    .select(INTERNSHIP_COLUMNS)
+    .eq("student_id", auth.userId)
+    .in("status", ["active", "paused", "draft"])
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function updateInternship(
+  internshipId: string,
+  input: UpdateInternshipInput,
+): Promise<InternshipResult<Internship>> {
+  const parsedId = internshipIdSchema.safeParse(internshipId);
+  const parsed = updateInternshipInputSchema.safeParse(input);
+
+  if (!parsedId.success) {
+    return repositoryError("invalid_internship_id", "Invalid internship ID.");
+  }
+
+  if (!parsed.success) {
+    return repositoryError(
+      "invalid_internship_update",
+      parsed.error.issues[0]?.message ?? "Invalid internship update.",
+    );
+  }
+
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const updatePayload: TablesUpdate<"internships"> = {};
+
+  if (parsed.data.internshipTypeId !== undefined) {
+    updatePayload.internship_type_id = parsed.data.internshipTypeId;
+  }
+
+  if (parsed.data.organizationId !== undefined) {
+    updatePayload.organization_id = parsed.data.organizationId;
+  }
+
+  if (parsed.data.supervisorId !== undefined) {
+    updatePayload.supervisor_id = parsed.data.supervisorId;
+  }
+
+  if (parsed.data.startDate !== undefined) {
+    updatePayload.start_date = parsed.data.startDate;
+  }
+
+  if (parsed.data.expectedEndDate !== undefined) {
+    updatePayload.expected_end_date = parsed.data.expectedEndDate;
+  }
+
+  if (parsed.data.status !== undefined) {
+    updatePayload.status = parsed.data.status;
+  }
+
+  const { data, error } = await auth.supabase
+    .from("internships")
+    .update(updatePayload)
+    .eq("id", parsedId.data)
+    .eq("student_id", auth.userId)
+    .select(INTERNSHIP_COLUMNS)
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  if (!data) {
+    return repositoryError(
+      "internship_not_found_or_not_editable",
+      "Internship was not found or cannot be edited by the current user.",
+    );
+  }
+
+  return { ok: true, data };
+}

--- a/src/features/internships/schemas/internship.schema.ts
+++ b/src/features/internships/schemas/internship.schema.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+const optionalUuidSchema = z.preprocess(
+  (value) => {
+    if (typeof value === "string" && value.trim().length === 0) {
+      return null;
+    }
+
+    return value;
+  },
+  z.string().uuid().nullable().optional(),
+);
+
+const optionalDateSchema = z.preprocess(
+  (value) => {
+    if (typeof value === "string" && value.trim().length === 0) {
+      return null;
+    }
+
+    return value;
+  },
+  z.iso.date().nullable().optional(),
+);
+
+export const internshipIdSchema = z.string().uuid();
+
+export const studentInternshipStatusSchema = z.enum([
+  "active",
+  "paused",
+  "cancelled",
+]);
+
+export const createInternshipInputSchema = z
+  .object({
+    internshipTypeId: z.string().uuid(),
+    organizationId: z.string().uuid(),
+    supervisorId: optionalUuidSchema,
+    startDate: z.iso.date(),
+    expectedEndDate: optionalDateSchema,
+  })
+  .refine(
+    (input) =>
+      !input.expectedEndDate || input.expectedEndDate >= input.startDate,
+    {
+      message: "A data prevista de término não pode ser anterior ao início.",
+      path: ["expectedEndDate"],
+    },
+  );
+
+export const updateInternshipInputSchema = z
+  .object({
+    internshipTypeId: z.string().uuid().optional(),
+    organizationId: z.string().uuid().optional(),
+    supervisorId: optionalUuidSchema,
+    startDate: z.iso.date().optional(),
+    expectedEndDate: optionalDateSchema,
+    status: studentInternshipStatusSchema.optional(),
+  })
+  .refine(
+    (input) => Object.values(input).some((value) => value !== undefined),
+    {
+      message: "Informe ao menos um campo para atualizar.",
+    },
+  )
+  .refine(
+    (input) =>
+      !input.startDate ||
+      !input.expectedEndDate ||
+      input.expectedEndDate >= input.startDate,
+    {
+      message: "A data prevista de término não pode ser anterior ao início.",
+      path: ["expectedEndDate"],
+    },
+  );
+
+export type CreateInternshipInput = z.output<
+  typeof createInternshipInputSchema
+>;
+export type UpdateInternshipInput = z.output<
+  typeof updateInternshipInputSchema
+>;
+export type StudentInternshipStatus = z.output<
+  typeof studentInternshipStatusSchema
+>;

--- a/src/features/internships/types.ts
+++ b/src/features/internships/types.ts
@@ -1,0 +1,13 @@
+import type { Enums, Tables } from "@/types/database";
+
+export type Internship = Tables<"internships">;
+export type InternshipStatus = Enums<"internship_status">;
+
+export type InternshipRepositoryError = {
+  code: string;
+  message: string;
+};
+
+export type InternshipResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: InternshipRepositoryError };


### PR DESCRIPTION
Implementa a STG-016 com a camada central de acesso a estágios.

Inclui:
- schemas Zod de criação e atualização;
- `createInternship()` sem enviar campos protegidos;
- `getInternship()`;
- `listStudentInternships()`;
- `getCurrentInternship()`;
- `updateInternship()`;
- filtros explícitos por `student_id` além da RLS;
- status `completed` fora da API de mutação do aluno;
- erros normalizados.

Validação concluída:
- npm ci
- lint
- typecheck
- build

Closes #29