### PR TITLE
feat: build internship registration flow

### DIFF
--- a/src/app/(protected)/internships/new/page.tsx
+++ b/src/app/(protected)/internships/new/page.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+
+import {
+  listActiveAcademicInstitutions,
+  listAllActiveCourses,
+  listAllActiveInternshipTypes,
+} from "@/features/academic-catalog";
+import { InternshipRegistrationForm } from "@/features/internships/components/internship-registration-form";
+import { listOrganizations } from "@/features/organizations";
+import { listStudentSupervisors } from "@/features/supervisors";
+import { getCurrentProfile } from "@/features/users";
+
+export default async function NewInternshipPage() {
+  const [
+    profileResult,
+    institutionsResult,
+    coursesResult,
+    internshipTypesResult,
+    organizationsResult,
+    supervisorsResult,
+  ] = await Promise.all([
+    getCurrentProfile(),
+    listActiveAcademicInstitutions(),
+    listAllActiveCourses(),
+    listAllActiveInternshipTypes(),
+    listOrganizations(),
+    listStudentSupervisors(),
+  ]);
+
+  const hasLoadError =
+    !profileResult.ok ||
+    !profileResult.data ||
+    !institutionsResult.ok ||
+    !coursesResult.ok ||
+    !internshipTypesResult.ok ||
+    !organizationsResult.ok ||
+    !supervisorsResult.ok;
+
+  if (hasLoadError) {
+    return (
+      <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8">
+        <p className="text-sm font-semibold text-amber-800">Cadastro indisponível</p>
+        <h1 className="mt-2 text-2xl font-bold text-amber-950">
+          Não foi possível preparar os dados do estágio.
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-amber-800">
+          Sua sessão continua protegida. Atualize a página e tente novamente.
+        </p>
+        <Link href="/internships" className="mt-5 inline-flex font-semibold text-amber-950 underline">
+          Voltar para Meu Estágio
+        </Link>
+      </section>
+    );
+  }
+
+  if (
+    institutionsResult.data.length === 0 ||
+    coursesResult.data.length === 0 ||
+    internshipTypesResult.data.length === 0
+  ) {
+    return (
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <p className="text-sm font-semibold text-indigo-600">Novo estágio</p>
+        <h1 className="mt-2 text-2xl font-bold text-slate-950">
+          O catálogo acadêmico ainda não está configurado.
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+          É necessário existir ao menos uma instituição, curso e modalidade ativos antes do primeiro cadastro.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <Link href="/internships" className="text-sm font-semibold text-indigo-600 hover:text-indigo-500">
+          ← Meu Estágio
+        </Link>
+        <p className="mt-5 text-sm font-semibold text-indigo-600">Novo estágio</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">
+          Cadastre seu estágio supervisionado
+        </h1>
+        <p className="mt-3 max-w-3xl text-base leading-7 text-slate-600">
+          Informe o vínculo acadêmico, a instituição concedente e o período. O StageTrack protege sua identidade e copia automaticamente a carga obrigatória definida pela modalidade.
+        </p>
+      </section>
+
+      <InternshipRegistrationForm
+        institutions={institutionsResult.data}
+        courses={coursesResult.data}
+        internshipTypes={internshipTypesResult.data}
+        organizations={organizationsResult.data}
+        supervisors={supervisorsResult.data}
+        initialCourseId={profileResult.data.course_id}
+      />
+    </div>
+  );
+}

--- a/src/app/(protected)/internships/new/page.tsx
+++ b/src/app/(protected)/internships/new/page.tsx
@@ -27,16 +27,15 @@ export default async function NewInternshipPage() {
     listStudentSupervisors(),
   ]);
 
-  const hasLoadError =
+  if (
     !profileResult.ok ||
     !profileResult.data ||
     !institutionsResult.ok ||
     !coursesResult.ok ||
     !internshipTypesResult.ok ||
     !organizationsResult.ok ||
-    !supervisorsResult.ok;
-
-  if (hasLoadError) {
+    !supervisorsResult.ok
+  ) {
     return (
       <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8">
         <p className="text-sm font-semibold text-amber-800">Cadastro indisponível</p>
@@ -53,6 +52,7 @@ export default async function NewInternshipPage() {
     );
   }
 
+  const profile = profileResult.data;
   const eligibleCourses = coursesResult.data.filter((course) =>
     internshipTypesResult.data.some((type) => type.course_id === course.id),
   );
@@ -105,7 +105,7 @@ export default async function NewInternshipPage() {
         internshipTypes={eligibleInternshipTypes}
         organizations={organizationsResult.data}
         supervisors={supervisorsResult.data}
-        initialCourseId={profileResult.data.course_id}
+        initialCourseId={profile.course_id}
       />
     </div>
   );

--- a/src/app/(protected)/internships/new/page.tsx
+++ b/src/app/(protected)/internships/new/page.tsx
@@ -53,10 +53,23 @@ export default async function NewInternshipPage() {
     );
   }
 
+  const eligibleCourses = coursesResult.data.filter((course) =>
+    internshipTypesResult.data.some((type) => type.course_id === course.id),
+  );
+  const eligibleInstitutions = institutionsResult.data.filter((institution) =>
+    eligibleCourses.some(
+      (course) => course.academic_institution_id === institution.id,
+    ),
+  );
+  const eligibleCourseIds = new Set(eligibleCourses.map((course) => course.id));
+  const eligibleInternshipTypes = internshipTypesResult.data.filter((type) =>
+    eligibleCourseIds.has(type.course_id),
+  );
+
   if (
-    institutionsResult.data.length === 0 ||
-    coursesResult.data.length === 0 ||
-    internshipTypesResult.data.length === 0
+    eligibleInstitutions.length === 0 ||
+    eligibleCourses.length === 0 ||
+    eligibleInternshipTypes.length === 0
   ) {
     return (
       <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
@@ -87,9 +100,9 @@ export default async function NewInternshipPage() {
       </section>
 
       <InternshipRegistrationForm
-        institutions={institutionsResult.data}
-        courses={coursesResult.data}
-        internshipTypes={internshipTypesResult.data}
+        institutions={eligibleInstitutions}
+        courses={eligibleCourses}
+        internshipTypes={eligibleInternshipTypes}
         organizations={organizationsResult.data}
         supervisors={supervisorsResult.data}
         initialCourseId={profileResult.data.course_id}

--- a/src/app/(protected)/internships/page.tsx
+++ b/src/app/(protected)/internships/page.tsx
@@ -1,22 +1,100 @@
-export default function InternshipsPage() {
-  return (
-    <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
-      <p className="text-sm font-semibold text-indigo-600">Estágios</p>
-      <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">
-        Seus estágios supervisionados
-      </h1>
-      <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600">
-        A rota já está protegida e pronta para receber o cadastro e o
-        acompanhamento dos estágios nas próximas etapas do projeto.
-      </p>
+import Link from "next/link";
 
-      <div className="mt-8 rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-6">
-        <p className="text-sm font-semibold text-slate-800">Nenhum estágio cadastrado ainda.</p>
-        <p className="mt-2 text-sm leading-6 text-slate-500">
-          O fluxo de criação do primeiro estágio será implementado no próximo
-          bloco funcional do StageTrack.
-        </p>
-      </div>
-    </section>
+import { listStudentInternships } from "@/features/internships";
+
+const STATUS_LABELS = {
+  draft: "Rascunho",
+  active: "Ativo",
+  paused: "Pausado",
+  completed: "Concluído",
+  cancelled: "Cancelado",
+} as const;
+
+function minutesLabel(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining === 0 ? `${hours}h` : `${hours}h${String(remaining).padStart(2, "0")}`;
+}
+
+type InternshipsPageProps = {
+  searchParams: Promise<{ created?: string }>;
+};
+
+export default async function InternshipsPage({ searchParams }: InternshipsPageProps) {
+  const [{ created }, internshipsResult] = await Promise.all([
+    searchParams,
+    listStudentInternships(),
+  ]);
+
+  if (!internshipsResult.ok) {
+    return (
+      <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8">
+        <p className="text-sm font-semibold text-amber-800">Meu Estágio</p>
+        <h1 className="mt-2 text-2xl font-bold text-amber-950">Não foi possível carregar seus estágios.</h1>
+        <p className="mt-3 text-sm text-amber-800">Atualize a página e tente novamente.</p>
+      </section>
+    );
+  }
+
+  const internships = internshipsResult.data;
+
+  return (
+    <div className="space-y-6">
+      {created === "1" && (
+        <div role="status" className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm font-medium text-emerald-800">
+          Estágio cadastrado com sucesso. Ele foi criado como rascunho e já está protegido pela sua conta.
+        </div>
+      )}
+
+      <section className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold text-indigo-600">Meu Estágio</p>
+          <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">Seus estágios supervisionados</h1>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600">
+            Cadastre e acompanhe os vínculos de estágio associados à sua jornada acadêmica.
+          </p>
+        </div>
+        <Link
+          href="/internships/new"
+          className="inline-flex items-center justify-center rounded-2xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500"
+        >
+          Cadastrar estágio
+        </Link>
+      </section>
+
+      {internships.length === 0 ? (
+        <section className="rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center shadow-sm">
+          <h2 className="text-lg font-bold text-slate-950">Nenhum estágio cadastrado ainda</h2>
+          <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600">
+            Comece selecionando seu curso, modalidade e instituição concedente. A carga obrigatória será preenchida automaticamente.
+          </p>
+          <Link href="/internships/new" className="mt-5 inline-flex font-semibold text-indigo-600 hover:text-indigo-500">
+            Cadastrar meu primeiro estágio →
+          </Link>
+        </section>
+      ) : (
+        <section className="grid gap-4 lg:grid-cols-2">
+          {internships.map((internship) => (
+            <article key={internship.id} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <div className="flex items-center justify-between gap-4">
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold uppercase tracking-wider text-slate-700">
+                  {STATUS_LABELS[internship.status]}
+                </span>
+                <span className="text-sm font-semibold text-indigo-600">{minutesLabel(internship.required_minutes)}</span>
+              </div>
+              <p className="mt-5 text-xs font-bold uppercase tracking-wider text-slate-500">Início</p>
+              <p className="mt-1 font-semibold text-slate-950">{new Date(`${internship.start_date}T12:00:00`).toLocaleDateString("pt-BR")}</p>
+              <p className="mt-4 text-xs font-bold uppercase tracking-wider text-slate-500">Previsão de término</p>
+              <p className="mt-1 font-semibold text-slate-950">
+                {internship.expected_end_date
+                  ? new Date(`${internship.expected_end_date}T12:00:00`).toLocaleDateString("pt-BR")
+                  : "Não informada"}
+              </p>
+              <p className="mt-5 text-xs text-slate-400">ID {internship.id}</p>
+            </article>
+          ))}
+        </section>
+      )}
+    </div>
   );
 }

--- a/src/features/academic-catalog/index.ts
+++ b/src/features/academic-catalog/index.ts
@@ -2,6 +2,8 @@ export {
   listActiveAcademicInstitutions,
   listActiveCourses,
   listActiveInternshipTypes,
+  listAllActiveCourses,
+  listAllActiveInternshipTypes,
 } from "./repositories/academic-catalog.repository";
 
 export { catalogIdSchema } from "./schemas/catalog.schema";

--- a/src/features/academic-catalog/repositories/academic-catalog.repository.ts
+++ b/src/features/academic-catalog/repositories/academic-catalog.repository.ts
@@ -54,6 +54,21 @@ export async function listActiveAcademicInstitutions(): Promise<
   return { ok: true, data };
 }
 
+export async function listAllActiveCourses(): Promise<CatalogResult<Course[]>> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("courses")
+    .select(COURSE_COLUMNS)
+    .eq("active", true)
+    .order("name", { ascending: true });
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
 export async function listActiveCourses(
   academicInstitutionId: string,
 ): Promise<CatalogResult<Course[]>> {
@@ -68,6 +83,23 @@ export async function listActiveCourses(
     .from("courses")
     .select(COURSE_COLUMNS)
     .eq("academic_institution_id", parsedId.data)
+    .eq("active", true)
+    .order("name", { ascending: true });
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function listAllActiveInternshipTypes(): Promise<
+  CatalogResult<InternshipType[]>
+> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("internship_types")
+    .select(INTERNSHIP_TYPE_COLUMNS)
     .eq("active", true)
     .order("name", { ascending: true });
 

--- a/src/features/internships/actions/internship-registration.actions.ts
+++ b/src/features/internships/actions/internship-registration.actions.ts
@@ -1,0 +1,157 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import type { ZodError } from "zod";
+
+import {
+  listActiveCourses,
+  listActiveInternshipTypes,
+} from "@/features/academic-catalog";
+import {
+  createOrganization,
+  listOrganizations,
+} from "@/features/organizations";
+import { listStudentSupervisors } from "@/features/supervisors";
+import {
+  getCurrentProfile,
+  setCurrentProfileCourse,
+} from "@/features/users";
+
+import { createInternship } from "../repositories/internship.repository";
+import { internshipRegistrationFormSchema } from "../schemas/internship-registration.schema";
+import type {
+  InternshipRegistrationActionState,
+  InternshipRegistrationField,
+} from "../types.registration";
+
+function values(formData: FormData) {
+  return Object.fromEntries(formData.entries());
+}
+
+function validationState(
+  error: ZodError,
+): InternshipRegistrationActionState {
+  const fieldErrors: Partial<Record<InternshipRegistrationField, string>> = {};
+
+  for (const issue of error.issues) {
+    const field = issue.path[0];
+
+    if (typeof field === "string" && !(field in fieldErrors)) {
+      fieldErrors[field as InternshipRegistrationField] = issue.message;
+    }
+  }
+
+  return {
+    status: "error",
+    message: "Revise os campos destacados antes de continuar.",
+    fieldErrors,
+  };
+}
+
+function errorState(message: string): InternshipRegistrationActionState {
+  return { status: "error", message };
+}
+
+export async function registerInternshipAction(
+  _previousState: InternshipRegistrationActionState,
+  formData: FormData,
+): Promise<InternshipRegistrationActionState> {
+  const parsed = internshipRegistrationFormSchema.safeParse(values(formData));
+
+  if (!parsed.success) {
+    return validationState(parsed.error);
+  }
+
+  const input = parsed.data;
+
+  const [profileResult, coursesResult, typesResult] = await Promise.all([
+    getCurrentProfile(),
+    listActiveCourses(input.academicInstitutionId),
+    listActiveInternshipTypes(input.courseId),
+  ]);
+
+  if (!profileResult.ok || !profileResult.data) {
+    return errorState("Não foi possível carregar seu perfil acadêmico.");
+  }
+
+  if (!coursesResult.ok || !coursesResult.data.some((course) => course.id === input.courseId)) {
+    return errorState("O curso selecionado não pertence à instituição informada ou não está ativo.");
+  }
+
+  if (!typesResult.ok || !typesResult.data.some((type) => type.id === input.internshipTypeId)) {
+    return errorState("A modalidade selecionada não pertence ao curso informado ou não está ativa.");
+  }
+
+  let organizationId: string;
+
+  if (input.organizationMode === "new") {
+    const organizationResult = await createOrganization({
+      name: input.newOrganizationName ?? "",
+      document: input.newOrganizationDocument,
+      email: input.newOrganizationEmail,
+      phone: input.newOrganizationPhone,
+      address: input.newOrganizationAddress,
+      city: input.newOrganizationCity,
+      state: input.newOrganizationState,
+      postalCode: input.newOrganizationPostalCode,
+    });
+
+    if (!organizationResult.ok) {
+      return errorState(
+        organizationResult.error.code === "23505"
+          ? "Já existe uma concedente com esses dados. Selecione-a na lista existente."
+          : "Não foi possível cadastrar a instituição concedente.",
+      );
+    }
+
+    organizationId = organizationResult.data.id;
+  } else {
+    const organizationsResult = await listOrganizations();
+
+    if (
+      !organizationsResult.ok ||
+      !input.organizationId ||
+      !organizationsResult.data.some((organization) => organization.id === input.organizationId)
+    ) {
+      return errorState("A instituição concedente selecionada não está disponível.");
+    }
+
+    organizationId = input.organizationId;
+  }
+
+  if (input.supervisorId) {
+    const supervisorsResult = await listStudentSupervisors();
+    const supervisor = supervisorsResult.ok
+      ? supervisorsResult.data.find((item) => item.id === input.supervisorId)
+      : null;
+
+    if (!supervisor || supervisor.organization_id !== organizationId) {
+      return errorState("O supervisor selecionado não pertence à concedente informada.");
+    }
+  }
+
+  const courseResult = await setCurrentProfileCourse(input.courseId);
+
+  if (!courseResult.ok) {
+    return errorState("Não foi possível vincular o curso ao seu perfil.");
+  }
+
+  const internshipResult = await createInternship({
+    internshipTypeId: input.internshipTypeId,
+    organizationId,
+    supervisorId: input.supervisorId,
+    startDate: input.startDate,
+    expectedEndDate: input.expectedEndDate,
+  });
+
+  if (!internshipResult.ok) {
+    return errorState(
+      "Não foi possível cadastrar o estágio. Verifique modalidade, concedente, supervisor e datas.",
+    );
+  }
+
+  revalidatePath("/dashboard");
+  revalidatePath("/internships");
+  redirect("/internships?created=1");
+}

--- a/src/features/internships/components/internship-registration-form.tsx
+++ b/src/features/internships/components/internship-registration-form.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { useActionState, useMemo, useState } from "react";
+import { useFormStatus } from "react-dom";
+
+import type {
+  AcademicInstitution,
+  Course,
+  InternshipType,
+} from "@/features/academic-catalog";
+import type { Organization } from "@/features/organizations";
+import type { Supervisor } from "@/features/supervisors";
+
+import { registerInternshipAction } from "../actions/internship-registration.actions";
+import {
+  INITIAL_INTERNSHIP_REGISTRATION_STATE,
+  type InternshipRegistrationField,
+} from "../types.registration";
+
+type InternshipRegistrationFormProps = {
+  institutions: AcademicInstitution[];
+  courses: Course[];
+  internshipTypes: InternshipType[];
+  organizations: Organization[];
+  supervisors: Supervisor[];
+  initialCourseId?: string | null;
+};
+
+function minutesLabel(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining === 0 ? `${hours}h` : `${hours}h${String(remaining).padStart(2, "0")}`;
+}
+
+function FieldError({
+  field,
+  errors,
+}: {
+  field: InternshipRegistrationField;
+  errors?: Partial<Record<InternshipRegistrationField, string>>;
+}) {
+  const message = errors?.[field];
+  return message ? <p className="mt-1 text-sm text-rose-600">{message}</p> : null;
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="inline-flex w-full items-center justify-center rounded-2xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+    >
+      {pending ? "Cadastrando estágio..." : "Cadastrar estágio"}
+    </button>
+  );
+}
+
+const inputClass =
+  "mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-100";
+
+export function InternshipRegistrationForm({
+  institutions,
+  courses,
+  internshipTypes,
+  organizations,
+  supervisors,
+  initialCourseId,
+}: InternshipRegistrationFormProps) {
+  const initialCourse =
+    courses.find((course) => course.id === initialCourseId) ?? courses[0];
+  const [institutionId, setInstitutionId] = useState(
+    initialCourse?.academic_institution_id ?? institutions[0]?.id ?? "",
+  );
+
+  const availableCourses = useMemo(
+    () => courses.filter((course) => course.academic_institution_id === institutionId),
+    [courses, institutionId],
+  );
+  const validInitialCourse = availableCourses.some(
+    (course) => course.id === initialCourse?.id,
+  )
+    ? initialCourse?.id ?? ""
+    : availableCourses[0]?.id ?? "";
+  const [courseId, setCourseId] = useState(validInitialCourse);
+
+  const availableTypes = useMemo(
+    () => internshipTypes.filter((type) => type.course_id === courseId),
+    [internshipTypes, courseId],
+  );
+  const [internshipTypeId, setInternshipTypeId] = useState(
+    availableTypes[0]?.id ?? "",
+  );
+
+  const [organizationMode, setOrganizationMode] = useState<"existing" | "new">(
+    organizations.length > 0 ? "existing" : "new",
+  );
+  const [organizationId, setOrganizationId] = useState(
+    organizations[0]?.id ?? "",
+  );
+  const [supervisorId, setSupervisorId] = useState("");
+
+  const availableSupervisors = useMemo(
+    () => supervisors.filter((supervisor) => supervisor.organization_id === organizationId),
+    [supervisors, organizationId],
+  );
+  const selectedType = internshipTypes.find(
+    (type) => type.id === internshipTypeId,
+  );
+
+  const [state, formAction] = useActionState(
+    registerInternshipAction,
+    INITIAL_INTERNSHIP_REGISTRATION_STATE,
+  );
+
+  function changeInstitution(nextInstitutionId: string) {
+    setInstitutionId(nextInstitutionId);
+    const nextCourse = courses.find(
+      (course) => course.academic_institution_id === nextInstitutionId,
+    );
+    setCourseId(nextCourse?.id ?? "");
+    const nextType = internshipTypes.find(
+      (type) => type.course_id === nextCourse?.id,
+    );
+    setInternshipTypeId(nextType?.id ?? "");
+  }
+
+  function changeCourse(nextCourseId: string) {
+    setCourseId(nextCourseId);
+    const nextType = internshipTypes.find(
+      (type) => type.course_id === nextCourseId,
+    );
+    setInternshipTypeId(nextType?.id ?? "");
+  }
+
+  return (
+    <form action={formAction} className="space-y-8" noValidate>
+      {state.status === "error" && (
+        <div role="alert" className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+          {state.message}
+        </div>
+      )}
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm sm:p-7">
+        <div>
+          <p className="text-sm font-semibold text-indigo-600">1. Vínculo acadêmico</p>
+          <h2 className="mt-1 text-xl font-bold text-slate-950">Curso e modalidade</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            A carga obrigatória é definida pela modalidade e não pode ser digitada manualmente.
+          </p>
+        </div>
+
+        <div className="mt-6 grid gap-5 md:grid-cols-2">
+          <label className="text-sm font-semibold text-slate-800">
+            Instituição de ensino
+            <select
+              name="academicInstitutionId"
+              value={institutionId}
+              onChange={(event) => changeInstitution(event.target.value)}
+              className={inputClass}
+              required
+            >
+              {institutions.map((institution) => (
+                <option key={institution.id} value={institution.id}>
+                  {institution.acronym ? `${institution.acronym} — ` : ""}{institution.name}
+                </option>
+              ))}
+            </select>
+            <FieldError field="academicInstitutionId" errors={state.fieldErrors} />
+          </label>
+
+          <label className="text-sm font-semibold text-slate-800">
+            Curso
+            <select
+              name="courseId"
+              value={courseId}
+              onChange={(event) => changeCourse(event.target.value)}
+              className={inputClass}
+              required
+            >
+              {availableCourses.map((course) => (
+                <option key={course.id} value={course.id}>
+                  {course.name}
+                </option>
+              ))}
+            </select>
+            <FieldError field="courseId" errors={state.fieldErrors} />
+          </label>
+
+          <label className="text-sm font-semibold text-slate-800 md:col-span-2">
+            Modalidade / componente
+            <select
+              name="internshipTypeId"
+              value={internshipTypeId}
+              onChange={(event) => setInternshipTypeId(event.target.value)}
+              className={inputClass}
+              required
+            >
+              {availableTypes.map((type) => (
+                <option key={type.id} value={type.id}>
+                  {type.name} — {minutesLabel(type.required_minutes)}
+                </option>
+              ))}
+            </select>
+            <FieldError field="internshipTypeId" errors={state.fieldErrors} />
+          </label>
+        </div>
+
+        {selectedType && (
+          <div className="mt-5 rounded-2xl bg-indigo-50 p-4">
+            <p className="text-xs font-bold uppercase tracking-wider text-indigo-600">Carga obrigatória</p>
+            <p className="mt-1 text-lg font-bold text-indigo-950">{minutesLabel(selectedType.required_minutes)}</p>
+            {selectedType.description && <p className="mt-1 text-sm text-indigo-800">{selectedType.description}</p>}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm sm:p-7">
+        <p className="text-sm font-semibold text-indigo-600">2. Instituição concedente</p>
+        <h2 className="mt-1 text-xl font-bold text-slate-950">Onde o estágio será realizado</h2>
+
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+          <label className="flex cursor-pointer items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-800">
+            <input
+              type="radio"
+              name="organizationMode"
+              value="existing"
+              checked={organizationMode === "existing"}
+              disabled={organizations.length === 0}
+              onChange={() => setOrganizationMode("existing")}
+            />
+            Selecionar existente
+          </label>
+          <label className="flex cursor-pointer items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-800">
+            <input
+              type="radio"
+              name="organizationMode"
+              value="new"
+              checked={organizationMode === "new"}
+              onChange={() => {
+                setOrganizationMode("new");
+                setSupervisorId("");
+              }}
+            />
+            Cadastrar nova
+          </label>
+        </div>
+
+        {organizationMode === "existing" ? (
+          <div className="mt-6 grid gap-5 md:grid-cols-2">
+            <label className="text-sm font-semibold text-slate-800">
+              Concedente
+              <select
+                name="organizationId"
+                value={organizationId}
+                onChange={(event) => {
+                  setOrganizationId(event.target.value);
+                  setSupervisorId("");
+                }}
+                className={inputClass}
+                required
+              >
+                {organizations.map((organization) => (
+                  <option key={organization.id} value={organization.id}>{organization.name}</option>
+                ))}
+              </select>
+              <FieldError field="organizationId" errors={state.fieldErrors} />
+            </label>
+
+            <label className="text-sm font-semibold text-slate-800">
+              Supervisor responsável <span className="font-normal text-slate-500">(opcional)</span>
+              <select
+                name="supervisorId"
+                value={supervisorId}
+                onChange={(event) => setSupervisorId(event.target.value)}
+                className={inputClass}
+              >
+                <option value="">Informar depois</option>
+                {availableSupervisors.map((supervisor) => (
+                  <option key={supervisor.id} value={supervisor.id}>
+                    {supervisor.name}{supervisor.position ? ` — ${supervisor.position}` : ""}
+                  </option>
+                ))}
+              </select>
+              <FieldError field="supervisorId" errors={state.fieldErrors} />
+            </label>
+          </div>
+        ) : (
+          <div className="mt-6 grid gap-5 md:grid-cols-2">
+            <label className="text-sm font-semibold text-slate-800 md:col-span-2">
+              Nome da concedente
+              <input name="newOrganizationName" className={inputClass} placeholder="Ex.: Colégio Estadual..." required />
+              <FieldError field="newOrganizationName" errors={state.fieldErrors} />
+            </label>
+            <label className="text-sm font-semibold text-slate-800">
+              CNPJ / documento <span className="font-normal text-slate-500">(opcional)</span>
+              <input name="newOrganizationDocument" className={inputClass} />
+            </label>
+            <label className="text-sm font-semibold text-slate-800">
+              E-mail <span className="font-normal text-slate-500">(opcional)</span>
+              <input name="newOrganizationEmail" type="email" className={inputClass} />
+              <FieldError field="newOrganizationEmail" errors={state.fieldErrors} />
+            </label>
+            <label className="text-sm font-semibold text-slate-800">
+              Telefone <span className="font-normal text-slate-500">(opcional)</span>
+              <input name="newOrganizationPhone" className={inputClass} />
+            </label>
+            <label className="text-sm font-semibold text-slate-800">
+              CEP <span className="font-normal text-slate-500">(opcional)</span>
+              <input name="newOrganizationPostalCode" className={inputClass} />
+            </label>
+            <label className="text-sm font-semibold text-slate-800 md:col-span-2">
+              Endereço <span className="font-normal text-slate-500">(opcional)</span>
+              <input name="newOrganizationAddress" className={inputClass} />
+            </label>
+            <label className="text-sm font-semibold text-slate-800">
+              Cidade <span className="font-normal text-slate-500">(opcional)</span>
+              <input name="newOrganizationCity" className={inputClass} />
+            </label>
+            <label className="text-sm font-semibold text-slate-800">
+              Estado <span className="font-normal text-slate-500">(opcional)</span>
+              <input name="newOrganizationState" className={inputClass} />
+            </label>
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm sm:p-7">
+        <p className="text-sm font-semibold text-indigo-600">3. Período</p>
+        <h2 className="mt-1 text-xl font-bold text-slate-950">Datas do estágio</h2>
+        <div className="mt-6 grid gap-5 md:grid-cols-2">
+          <label className="text-sm font-semibold text-slate-800">
+            Data de início
+            <input name="startDate" type="date" className={inputClass} required />
+            <FieldError field="startDate" errors={state.fieldErrors} />
+          </label>
+          <label className="text-sm font-semibold text-slate-800">
+            Previsão de término <span className="font-normal text-slate-500">(opcional)</span>
+            <input name="expectedEndDate" type="date" className={inputClass} />
+            <FieldError field="expectedEndDate" errors={state.fieldErrors} />
+          </label>
+        </div>
+      </section>
+
+      <div className="flex flex-col gap-3 rounded-3xl border border-slate-200 bg-slate-50 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <p className="max-w-xl text-sm leading-6 text-slate-600">
+          O estágio será criado como rascunho. Sua identidade e a carga horária obrigatória são preenchidas e protegidas pelo banco.
+        </p>
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/src/features/internships/index.ts
+++ b/src/features/internships/index.ts
@@ -12,15 +12,21 @@ export {
   studentInternshipStatusSchema,
   updateInternshipInputSchema,
 } from "./schemas/internship.schema";
+export { internshipRegistrationFormSchema } from "./schemas/internship-registration.schema";
 
 export type {
   CreateInternshipInput,
   StudentInternshipStatus,
   UpdateInternshipInput,
 } from "./schemas/internship.schema";
+export type { InternshipRegistrationFormInput } from "./schemas/internship-registration.schema";
 export type {
   Internship,
   InternshipRepositoryError,
   InternshipResult,
   InternshipStatus,
 } from "./types";
+export type {
+  InternshipRegistrationActionState,
+  InternshipRegistrationField,
+} from "./types.registration";

--- a/src/features/internships/schemas/internship-registration.schema.ts
+++ b/src/features/internships/schemas/internship-registration.schema.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+
+const optionalUuid = z.preprocess(
+  (value) => (typeof value === "string" && value.trim() === "" ? null : value),
+  z.string().uuid().nullable().optional(),
+);
+
+const optionalText = (max: number) =>
+  z.preprocess(
+    (value) => (typeof value === "string" && value.trim() === "" ? null : value),
+    z.string().trim().max(max).nullable().optional(),
+  );
+
+const optionalEmail = z.preprocess(
+  (value) => (typeof value === "string" && value.trim() === "" ? null : value),
+  z.string().trim().email().max(254).nullable().optional(),
+);
+
+const optionalDate = z.preprocess(
+  (value) => (typeof value === "string" && value.trim() === "" ? null : value),
+  z.iso.date().nullable().optional(),
+);
+
+export const internshipRegistrationFormSchema = z
+  .object({
+    academicInstitutionId: z.string().uuid(),
+    courseId: z.string().uuid(),
+    internshipTypeId: z.string().uuid(),
+    organizationMode: z.enum(["existing", "new"]),
+    organizationId: optionalUuid,
+    supervisorId: optionalUuid,
+    newOrganizationName: optionalText(160),
+    newOrganizationDocument: optionalText(40),
+    newOrganizationEmail: optionalEmail,
+    newOrganizationPhone: optionalText(40),
+    newOrganizationAddress: optionalText(500),
+    newOrganizationCity: optionalText(120),
+    newOrganizationState: optionalText(120),
+    newOrganizationPostalCode: optionalText(30),
+    startDate: z.iso.date(),
+    expectedEndDate: optionalDate,
+  })
+  .superRefine((input, ctx) => {
+    if (input.organizationMode === "existing" && !input.organizationId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["organizationId"],
+        message: "Selecione a instituição concedente.",
+      });
+    }
+
+    if (
+      input.organizationMode === "new" &&
+      (!input.newOrganizationName || input.newOrganizationName.length < 2)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["newOrganizationName"],
+        message: "Informe o nome da nova concedente.",
+      });
+    }
+
+    if (
+      input.expectedEndDate &&
+      input.expectedEndDate < input.startDate
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["expectedEndDate"],
+        message: "A previsão de término não pode ser anterior ao início.",
+      });
+    }
+
+    if (input.organizationMode === "new" && input.supervisorId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["supervisorId"],
+        message: "Cadastre o supervisor depois de criar a nova concedente.",
+      });
+    }
+  });
+
+export type InternshipRegistrationFormInput = z.output<
+  typeof internshipRegistrationFormSchema
+>;

--- a/src/features/internships/types.registration.ts
+++ b/src/features/internships/types.registration.ts
@@ -1,0 +1,27 @@
+export type InternshipRegistrationField =
+  | "academicInstitutionId"
+  | "courseId"
+  | "internshipTypeId"
+  | "organizationMode"
+  | "organizationId"
+  | "supervisorId"
+  | "newOrganizationName"
+  | "newOrganizationDocument"
+  | "newOrganizationEmail"
+  | "newOrganizationPhone"
+  | "newOrganizationAddress"
+  | "newOrganizationCity"
+  | "newOrganizationState"
+  | "newOrganizationPostalCode"
+  | "startDate"
+  | "expectedEndDate";
+
+export type InternshipRegistrationActionState = {
+  status: "idle" | "error";
+  message?: string;
+  fieldErrors?: Partial<Record<InternshipRegistrationField, string>>;
+};
+
+export const INITIAL_INTERNSHIP_REGISTRATION_STATE: InternshipRegistrationActionState = {
+  status: "idle",
+};

--- a/src/features/supervisors/index.ts
+++ b/src/features/supervisors/index.ts
@@ -1,5 +1,6 @@
 export {
   createSupervisor,
+  listStudentSupervisors,
   listSupervisorsForOrganization,
   updateSupervisor,
 } from "./repositories/supervisor.repository";

--- a/src/features/supervisors/repositories/supervisor.repository.ts
+++ b/src/features/supervisors/repositories/supervisor.repository.ts
@@ -64,6 +64,27 @@ function supervisorPayload(input: SupervisorInput) {
   };
 }
 
+export async function listStudentSupervisors(): Promise<
+  SupervisorResult<Supervisor[]>
+> {
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("supervisors")
+    .select(SUPERVISOR_COLUMNS)
+    .order("name", { ascending: true });
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
 export async function listSupervisorsForOrganization(
   organizationId: string,
 ): Promise<SupervisorResult<Supervisor[]>> {

--- a/src/features/users/index.ts
+++ b/src/features/users/index.ts
@@ -1,10 +1,14 @@
 export {
   createCurrentProfile,
   getCurrentProfile,
+  setCurrentProfileCourse,
   updateCurrentProfile,
 } from "./repositories/profile.repository";
 
-export { profileInputSchema } from "./schemas/profile.schema";
+export {
+  profileCourseIdSchema,
+  profileInputSchema,
+} from "./schemas/profile.schema";
 
 export type { ProfileInput } from "./schemas/profile.schema";
 export type {

--- a/src/features/users/repositories/profile.repository.ts
+++ b/src/features/users/repositories/profile.repository.ts
@@ -3,6 +3,7 @@ import type { PostgrestError } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 
 import {
+  profileCourseIdSchema,
   profileInputSchema,
   type ProfileInput,
 } from "../schemas/profile.schema";
@@ -131,6 +132,35 @@ export async function updateCurrentProfile(
       full_name: parsed.data.fullName,
       registration_number: parsed.data.registrationNumber ?? null,
     })
+    .eq("id", auth.userId)
+    .select(PROFILE_COLUMNS)
+    .single();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function setCurrentProfileCourse(
+  courseId: string,
+): Promise<ProfileResult<Profile>> {
+  const parsedCourseId = profileCourseIdSchema.safeParse(courseId);
+
+  if (!parsedCourseId.success) {
+    return repositoryError("invalid_course_id", "Invalid academic course ID.");
+  }
+
+  const auth = await getAuthenticatedUserId();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("profiles")
+    .update({ course_id: parsedCourseId.data })
     .eq("id", auth.userId)
     .select(PROFILE_COLUMNS)
     .single();

--- a/src/features/users/schemas/profile.schema.ts
+++ b/src/features/users/schemas/profile.schema.ts
@@ -11,6 +11,8 @@ const registrationNumberSchema = z.preprocess(
   z.string().trim().min(1).max(50).nullable().optional(),
 );
 
+export const profileCourseIdSchema = z.string().uuid();
+
 export const profileInputSchema = z.object({
   fullName: z.string().trim().min(2).max(120),
   registrationNumber: registrationNumberSchema,


### PR DESCRIPTION
Implementa a STG-017 com onboarding acadêmico e cadastro real de estágio.

Inclui:
- rota `/internships/new`;
- seleção encadeada instituição → curso → modalidade;
- preview da carga obrigatória;
- concedente existente ou cadastro inline de nova concedente;
- supervisor opcional filtrado pela concedente;
- Server Action com validação Zod e repositories;
- vínculo do curso ao perfil;
- criação sem campos protegidos (`student_id`, `required_minutes`, `advisor_id`);
- loading e erros de formulário;
- redirect de sucesso para `/internships`;
- estado vazio e confirmação/listagem mínima na área Meu Estágio.

Closes #30