### PR TITLE
feat: connect dashboard to internship data

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,13 +1,41 @@
 import { DashboardOverview } from "@/features/dashboard/components/dashboard-overview";
 import type { DashboardViewModel } from "@/features/dashboard/types";
+import { getCurrentInternshipOverview } from "@/features/internships";
 
-const emptyDashboard: DashboardViewModel = {
-  internship: null,
-  activityCount: 0,
-  lastActivityAt: null,
-  recentActivities: [],
-};
+export default async function DashboardPage() {
+  const internshipResult = await getCurrentInternshipOverview();
 
-export default function DashboardPage() {
-  return <DashboardOverview model={emptyDashboard} />;
+  if (!internshipResult.ok) {
+    return (
+      <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8">
+        <p className="text-sm font-semibold text-amber-800">Dashboard indisponível</p>
+        <h1 className="mt-2 text-2xl font-bold text-amber-950">
+          Não foi possível carregar seu estágio agora.
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-amber-800">
+          Sua sessão continua protegida. Atualize a página e tente novamente.
+        </p>
+      </section>
+    );
+  }
+
+  const internship = internshipResult.data;
+  const model: DashboardViewModel = {
+    internship: internship
+      ? {
+          id: internship.id,
+          title: internship.internship_types.name,
+          organizationName: internship.organizations.name,
+          completedMinutes: 0,
+          requiredMinutes: internship.required_minutes,
+          expectedEndDate: internship.expected_end_date,
+          status: internship.status,
+        }
+      : null,
+    activityCount: 0,
+    lastActivityAt: null,
+    recentActivities: [],
+  };
+
+  return <DashboardOverview model={model} />;
 }

--- a/src/features/dashboard/components/dashboard-overview.tsx
+++ b/src/features/dashboard/components/dashboard-overview.tsx
@@ -31,7 +31,7 @@ export function DashboardOverview({ model }: DashboardOverviewProps) {
         </div>
 
         <Link
-          href="/internships"
+          href={internship ? "/internships" : "/internships/new"}
           className="inline-flex shrink-0 items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm shadow-indigo-200 transition hover:bg-indigo-500"
         >
           {internship ? "Ver Meu Estágio" : "Configurar Meu Estágio"}

--- a/src/features/dashboard/components/internship-progress-card.tsx
+++ b/src/features/dashboard/components/internship-progress-card.tsx
@@ -3,6 +3,14 @@ import Link from "next/link";
 import { formatDuration, progressPercentage } from "../formatters";
 import type { DashboardInternshipSummary } from "../types";
 
+const STATUS_LABELS = {
+  draft: "Rascunho",
+  active: "Ativo",
+  paused: "Pausado",
+  completed: "Concluído",
+  cancelled: "Cancelado",
+} as const;
+
 type InternshipProgressCardProps = {
   internship: DashboardInternshipSummary | null;
 };
@@ -46,10 +54,10 @@ export function InternshipProgressCard({
           </div>
 
           <Link
-            href="/internships"
+            href="/internships/new"
             className="mt-7 inline-flex items-center justify-center rounded-xl bg-white px-4 py-2.5 text-sm font-bold text-slate-950 transition hover:bg-indigo-50"
           >
-            Ir para Meu Estágio
+            Cadastrar estágio
           </Link>
         </div>
       </section>
@@ -69,9 +77,14 @@ export function InternshipProgressCard({
     <section className="rounded-3xl border border-slate-200 bg-slate-950 p-6 text-white shadow-sm sm:p-8">
       <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <span className="text-xs font-bold uppercase tracking-[0.16em] text-indigo-300">
-            Progresso do estágio
-          </span>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-xs font-bold uppercase tracking-[0.16em] text-indigo-300">
+              Progresso do estágio
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs font-semibold text-slate-200">
+              {STATUS_LABELS[internship.status]}
+            </span>
+          </div>
           <h2 className="mt-2 text-2xl font-black tracking-tight">
             {internship.title}
           </h2>

--- a/src/features/dashboard/types.ts
+++ b/src/features/dashboard/types.ts
@@ -1,3 +1,5 @@
+import type { InternshipStatus } from "@/features/internships";
+
 export type DashboardInternshipSummary = {
   id: string;
   title: string;
@@ -5,6 +7,7 @@ export type DashboardInternshipSummary = {
   completedMinutes: number;
   requiredMinutes: number;
   expectedEndDate: string | null;
+  status: InternshipStatus;
 };
 
 export type DashboardActivitySummary = {

--- a/src/features/internships/index.ts
+++ b/src/features/internships/index.ts
@@ -5,7 +5,10 @@ export {
   listStudentInternships,
   updateInternship,
 } from "./repositories/internship.repository";
-export { listStudentInternshipOverviews } from "./repositories/internship-overview.repository";
+export {
+  getCurrentInternshipOverview,
+  listStudentInternshipOverviews,
+} from "./repositories/internship-overview.repository";
 
 export {
   createInternshipInputSchema,

--- a/src/features/internships/repositories/internship-overview.repository.ts
+++ b/src/features/internships/repositories/internship-overview.repository.ts
@@ -44,27 +44,62 @@ function databaseError(error: PostgrestError): InternshipResult<never> {
   };
 }
 
-export async function listStudentInternshipOverviews(): Promise<
-  InternshipResult<InternshipOverview[]>
-> {
+async function getAuthenticatedContext() {
   const supabase = await createClient();
-  const { data: claimsData, error: claimsError } = await supabase.auth.getClaims();
-  const userId = claimsData?.claims?.sub;
+  const { data, error } = await supabase.auth.getClaims();
+  const userId = data?.claims?.sub;
 
-  if (claimsError || !userId) {
+  if (error || !userId) {
     return {
-      ok: false,
+      ok: false as const,
       error: {
-        code: claimsError?.code ?? "not_authenticated",
-        message: claimsError?.message ?? "Authenticated user is required.",
+        code: error?.code ?? "not_authenticated",
+        message: error?.message ?? "Authenticated user is required.",
       },
     };
   }
 
-  const { data, error } = await supabase
+  return { ok: true as const, supabase, userId };
+}
+
+export async function getCurrentInternshipOverview(): Promise<
+  InternshipResult<InternshipOverview | null>
+> {
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
     .from("internships")
     .select(INTERNSHIP_OVERVIEW_COLUMNS)
-    .eq("student_id", userId)
+    .eq("student_id", auth.userId)
+    .in("status", ["active", "paused", "draft"])
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data: data as InternshipOverview | null };
+}
+
+export async function listStudentInternshipOverviews(): Promise<
+  InternshipResult<InternshipOverview[]>
+> {
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("internships")
+    .select(INTERNSHIP_OVERVIEW_COLUMNS)
+    .eq("student_id", auth.userId)
     .order("created_at", { ascending: false });
 
   if (error) {


### PR DESCRIPTION
Implementa a STG-019 conectando o dashboard ao estágio corrente real.

Inclui:
- query limitada ao estágio `active`, `paused` ou `draft` mais recente;
- modalidade, concedente, carga obrigatória e status reais;
- horas realizadas = 0 até a Sprint 2;
- horas restantes derivadas da carga obrigatória;
- progresso inicial consistente;
- CTA vazio direcionando ao cadastro;
- componentes existentes da STG-009 reutilizados.

Closes #32