### PR TITLE
feat: add activity maintenance controls

### DIFF
--- a/src/app/(protected)/activities/[id]/edit/page.tsx
+++ b/src/app/(protected)/activities/[id]/edit/page.tsx
@@ -1,0 +1,185 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import {
+  getActivity,
+  updateActivityAction,
+} from "@/features/activities";
+
+type EditActivityPageProps = {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ error?: string }>;
+};
+
+export default async function EditActivityPage({
+  params,
+  searchParams,
+}: EditActivityPageProps) {
+  const [{ id }, query] = await Promise.all([params, searchParams]);
+  const result = await getActivity(id);
+
+  if (!result.ok || !result.data) {
+    notFound();
+  }
+
+  const activity = result.data;
+  const editable = activity.status === "draft" || activity.status === "submitted";
+
+  if (!editable) {
+    return (
+      <div className="space-y-6">
+        <Link
+          href="/activities"
+          className="inline-flex text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+        >
+          ← Voltar para atividades
+        </Link>
+        <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8 dark:border-amber-900 dark:bg-amber-950/40">
+          <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+            Registro bloqueado
+          </p>
+          <h1 className="mt-2 text-2xl font-bold text-amber-950 dark:text-amber-50">
+            Esta atividade já foi revisada.
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-amber-800 dark:text-amber-200">
+            Atividades aprovadas ou rejeitadas preservam o histórico e não podem mais ser alteradas pelo aluno.
+          </p>
+        </section>
+      </div>
+    );
+  }
+
+  const action = updateActivityAction.bind(null, activity.id);
+
+  return (
+    <div className="space-y-6 sm:space-y-8">
+      <div>
+        <Link
+          href="/activities"
+          className="inline-flex text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+        >
+          ← Voltar para atividades
+        </Link>
+        <p className="mt-6 text-sm font-semibold text-indigo-600 dark:text-indigo-400">
+          Editar registro
+        </p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950 dark:text-white">
+          Ajustar atividade
+        </h1>
+        <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600 dark:text-slate-300">
+          Enquanto o registro estiver pendente, você pode corrigir horários, turma e descrição. A duração será recalculada automaticamente.
+        </p>
+      </div>
+
+      {query.error ? (
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm font-semibold text-rose-800 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200">
+          {query.error === "invalid"
+            ? "Revise a data, os horários e a descrição da atividade."
+            : "Não foi possível editar este registro. Ele pode já ter sido revisado."}
+        </div>
+      ) : null}
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8 dark:border-slate-800 dark:bg-slate-900">
+        <form action={action} className="grid gap-5 sm:grid-cols-2">
+          <label className="block">
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Data</span>
+            <input
+              required
+              type="date"
+              name="activityDate"
+              defaultValue={activity.activity_date}
+              className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Turma / grupo</span>
+            <input
+              type="text"
+              name="groupLabel"
+              defaultValue={activity.group_label ?? ""}
+              className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Início</span>
+            <input
+              required
+              type="time"
+              name="startTime"
+              defaultValue={activity.start_time.slice(0, 5)}
+              className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Fim</span>
+            <input
+              required
+              type="time"
+              name="endTime"
+              defaultValue={activity.end_time.slice(0, 5)}
+              className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <label className="block sm:col-span-2">
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Professor / supervisor presente
+            </span>
+            <input
+              type="text"
+              name="teacherName"
+              defaultValue={activity.teacher_name ?? ""}
+              className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <label className="block sm:col-span-2">
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Descrição da atividade
+            </span>
+            <textarea
+              required
+              name="description"
+              rows={4}
+              defaultValue={activity.description}
+              className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <label className="block sm:col-span-2">
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Observações</span>
+            <textarea
+              name="notes"
+              rows={3}
+              defaultValue={activity.notes ?? ""}
+              className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <div className="sm:col-span-2 flex flex-col gap-3 border-t border-slate-200 pt-5 sm:flex-row sm:items-center sm:justify-between dark:border-slate-800">
+            <p className="text-xs leading-5 text-slate-500 dark:text-slate-400">
+              A edição preserva o status pendente e atualiza a carga horária automaticamente.
+            </p>
+            <div className="flex gap-3">
+              <Link
+                href="/activities"
+                className="inline-flex h-12 items-center justify-center rounded-xl border border-slate-300 px-5 text-sm font-bold text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                Cancelar
+              </Link>
+              <button
+                type="submit"
+                className="inline-flex h-12 items-center justify-center rounded-xl bg-indigo-600 px-6 text-sm font-bold text-white transition hover:bg-indigo-500"
+              >
+                Salvar alterações
+              </button>
+            </div>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(protected)/activities/page.tsx
+++ b/src/app/(protected)/activities/page.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 
-import { createActivityAction, listActivities } from "@/features/activities";
+import {
+  createActivityAction,
+  deleteActivityAction,
+  listActivities,
+} from "@/features/activities";
 import { getCurrentInternshipOverview } from "@/features/internships";
 
 const STATUS_LABELS = {
@@ -20,7 +24,9 @@ const STATUS_STYLES = {
 function durationLabel(minutes: number) {
   const hours = Math.floor(minutes / 60);
   const remaining = minutes % 60;
-  return remaining === 0 ? `${hours}h` : `${hours}h${String(remaining).padStart(2, "0")}`;
+  return remaining === 0
+    ? `${hours}h`
+    : `${hours}h${String(remaining).padStart(2, "0")}`;
 }
 
 function dateLabel(date: string) {
@@ -34,6 +40,8 @@ function timeLabel(time: string) {
 type ActivitiesPageProps = {
   searchParams: Promise<{
     created?: string;
+    updated?: string;
+    deleted?: string;
     error?: string;
   }>;
 };
@@ -70,7 +78,9 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
   }
 
   const activities = activitiesResult.data;
-  const countedActivities = activities.filter((activity) => activity.status !== "rejected");
+  const countedActivities = activities.filter(
+    (activity) => activity.status !== "rejected",
+  );
   const totalMinutes = countedActivities.reduce(
     (total, activity) => total + activity.duration_minutes,
     0,
@@ -79,17 +89,28 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
   return (
     <div className="space-y-6 sm:space-y-8">
       {params.created === "1" ? (
-        <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm font-semibold text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200">
+        <Notice tone="success">
           Atividade registrada. A carga horária já entrou no progresso provisório do estágio.
-        </div>
+        </Notice>
       ) : null}
-
+      {params.updated === "1" ? (
+        <Notice tone="success">
+          Atividade atualizada. A duração e o dashboard foram recalculados.
+        </Notice>
+      ) : null}
+      {params.deleted === "1" ? (
+        <Notice tone="success">
+          Atividade excluída. O progresso foi atualizado automaticamente.
+        </Notice>
+      ) : null}
       {params.error ? (
-        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm font-semibold text-rose-800 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200">
+        <Notice tone="error">
           {params.error === "invalid"
             ? "Revise a data, os horários e a descrição da atividade."
-            : "Não foi possível registrar a atividade. Verifique se o estágio está ativo e tente novamente."}
-        </div>
+            : params.error === "delete"
+              ? "Não foi possível excluir o registro. Ele pode já ter sido revisado."
+              : "Não foi possível concluir a operação. Verifique o estágio e tente novamente."}
+        </Notice>
       ) : null}
 
       <section>
@@ -98,7 +119,7 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
           Registros de atividades
         </h1>
         <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600 dark:text-slate-300">
-          Registre cada ida ao estágio. A duração é calculada automaticamente pelos horários informados.
+          Registre cada ida ao estágio. Enquanto o orientador ainda não revisou, você pode corrigir ou remover o registro.
         </p>
       </section>
 
@@ -120,22 +141,12 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
       ) : (
         <>
           <section className="grid gap-4 sm:grid-cols-3">
-            <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <p className="text-2xl font-bold text-slate-950 dark:text-white">
-                {durationLabel(totalMinutes)}
-              </p>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Horas registradas</p>
-            </div>
-            <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <p className="text-2xl font-bold text-slate-950 dark:text-white">{activities.length}</p>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Atividades</p>
-            </div>
-            <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <p className="text-2xl font-bold text-slate-950 dark:text-white">
-                {activities[0] ? dateLabel(activities[0].activity_date) : "—"}
-              </p>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Último registro</p>
-            </div>
+            <Metric value={durationLabel(totalMinutes)} label="Horas registradas" />
+            <Metric value={String(activities.length)} label="Atividades" />
+            <Metric
+              value={activities[0] ? dateLabel(activities[0].activity_date) : "—"}
+              label="Último registro"
+            />
           </section>
 
           <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8 dark:border-slate-800 dark:bg-slate-900">
@@ -149,101 +160,77 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
                   {internship.organizations.name}
                 </p>
               </div>
-              <span className={`w-fit rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider ${
-                internship.status === "active"
-                  ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
-                  : "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200"
-              }`}>
+              <span
+                className={`w-fit rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider ${
+                  internship.status === "active"
+                    ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
+                    : "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                }`}
+              >
                 {internship.status === "active" ? "Estágio ativo" : internship.status}
               </span>
             </div>
 
             {internship.status !== "active" ? (
               <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
-                Ative o estágio em <Link href="/internships" className="font-bold underline">Meu Estágio</Link> para registrar novas atividades.
+                Ative o estágio em{" "}
+                <Link href="/internships" className="font-bold underline">
+                  Meu Estágio
+                </Link>{" "}
+                para registrar novas atividades.
               </div>
             ) : (
               <form action={createActivityAction} className="mt-7 grid gap-5 sm:grid-cols-2">
                 <input type="hidden" name="internshipId" value={internship.id} />
-
-                <label className="block">
-                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Data</span>
-                  <input
-                    required
-                    type="date"
-                    name="activityDate"
-                    className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
-                  />
-                </label>
-
-                <label className="block">
-                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Turma / grupo</span>
+                <Field label="Data">
+                  <input required type="date" name="activityDate" className={inputClass} />
+                </Field>
+                <Field label="Turma / grupo">
                   <input
                     type="text"
                     name="groupLabel"
                     placeholder="Ex.: 8º ano A"
-                    className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+                    className={inputClass}
                   />
-                </label>
-
-                <label className="block">
-                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Início</span>
-                  <input
-                    required
-                    type="time"
-                    name="startTime"
-                    className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
-                  />
-                </label>
-
-                <label className="block">
-                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Fim</span>
-                  <input
-                    required
-                    type="time"
-                    name="endTime"
-                    className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
-                  />
-                </label>
-
-                <label className="block sm:col-span-2">
-                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Professor / supervisor presente</span>
+                </Field>
+                <Field label="Início">
+                  <input required type="time" name="startTime" className={inputClass} />
+                </Field>
+                <Field label="Fim">
+                  <input required type="time" name="endTime" className={inputClass} />
+                </Field>
+                <Field label="Professor / supervisor presente" full>
                   <input
                     type="text"
                     name="teacherName"
                     placeholder="Nome do professor acompanhado"
-                    className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+                    className={inputClass}
                   />
-                </label>
-
-                <label className="block sm:col-span-2">
-                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Descrição da atividade</span>
+                </Field>
+                <Field label="Descrição da atividade" full>
                   <textarea
                     required
                     name="description"
                     rows={4}
                     placeholder="Descreva o que foi acompanhado ou realizado durante o estágio."
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+                    className={textareaClass}
                   />
-                </label>
-
-                <label className="block sm:col-span-2">
-                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">Observações</span>
+                </Field>
+                <Field label="Observações" full>
                   <textarea
                     name="notes"
                     rows={3}
                     placeholder="Opcional: anotações, ocorrências ou pontos importantes."
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+                    className={textareaClass}
                   />
-                </label>
-
+                </Field>
                 <div className="sm:col-span-2 flex flex-col gap-3 border-t border-slate-200 pt-5 sm:flex-row sm:items-center sm:justify-between dark:border-slate-800">
                   <p className="text-xs leading-5 text-slate-500 dark:text-slate-400">
-                    O registro ficará pendente de validação. Até essa etapa existir, as horas aparecem como provisórias.
+                    O registro ficará pendente. Até a revisão, as horas aparecem como provisórias.
                   </p>
                   <button
                     type="submit"
-                    className="inline-flex h-12 shrink-0 items-center justify-center rounded-xl bg-indigo-600 px-6 text-sm font-bold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                    className="inline-flex h-12 shrink-0 items-center justify-center rounded-xl bg-indigo-600 px-6 text-sm font-bold text-white transition hover:bg-indigo-500"
                   >
                     Registrar atividade
                   </button>
@@ -256,67 +243,171 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
             <div className="flex items-end justify-between gap-4">
               <div>
                 <p className="text-sm font-semibold text-indigo-600 dark:text-indigo-400">Histórico</p>
-                <h2 className="mt-1 text-xl font-bold text-slate-950 dark:text-white">Atividades registradas</h2>
+                <h2 className="mt-1 text-xl font-bold text-slate-950 dark:text-white">
+                  Atividades registradas
+                </h2>
               </div>
-              <span className="text-sm text-slate-500 dark:text-slate-400">{activities.length} registro(s)</span>
+              <span className="text-sm text-slate-500 dark:text-slate-400">
+                {activities.length} registro(s)
+              </span>
             </div>
 
             {activities.length === 0 ? (
               <div className="mt-4 rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center dark:border-slate-700 dark:bg-slate-900">
-                <p className="font-semibold text-slate-900 dark:text-white">Nenhuma atividade registrada ainda.</p>
+                <p className="font-semibold text-slate-900 dark:text-white">
+                  Nenhuma atividade registrada ainda.
+                </p>
                 <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                   O primeiro registro aparecerá aqui e também alimentará seu dashboard.
                 </p>
               </div>
             ) : (
               <div className="mt-4 space-y-3">
-                {activities.map((activity) => (
-                  <article
-                    key={activity.id}
-                    className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
-                  >
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="min-w-0">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className={`rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider ${STATUS_STYLES[activity.status]}`}>
-                            {STATUS_LABELS[activity.status]}
-                          </span>
-                          <span className="text-sm font-bold text-indigo-600 dark:text-indigo-400">
-                            {durationLabel(activity.duration_minutes)}
-                          </span>
-                        </div>
-                        <h3 className="mt-3 font-bold text-slate-950 dark:text-white">
-                          {dateLabel(activity.activity_date)} · {timeLabel(activity.start_time)}–{timeLabel(activity.end_time)}
-                        </h3>
-                        <p className="mt-2 whitespace-pre-line text-sm leading-6 text-slate-600 dark:text-slate-300">
-                          {activity.description}
-                        </p>
-                      </div>
+                {activities.map((activity) => {
+                  const editable =
+                    activity.status === "draft" || activity.status === "submitted";
+                  const deleteAction = deleteActivityAction.bind(null, activity.id);
 
-                      {(activity.group_label || activity.teacher_name) ? (
-                        <div className="shrink-0 rounded-xl bg-slate-50 px-4 py-3 text-sm dark:bg-slate-950">
-                          {activity.group_label ? (
-                            <p className="font-semibold text-slate-800 dark:text-slate-200">{activity.group_label}</p>
+                  return (
+                    <article
+                      key={activity.id}
+                      className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+                    >
+                      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span
+                              className={`rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider ${STATUS_STYLES[activity.status]}`}
+                            >
+                              {STATUS_LABELS[activity.status]}
+                            </span>
+                            <span className="text-sm font-bold text-indigo-600 dark:text-indigo-400">
+                              {durationLabel(activity.duration_minutes)}
+                            </span>
+                          </div>
+                          <h3 className="mt-3 font-bold text-slate-950 dark:text-white">
+                            {dateLabel(activity.activity_date)} · {timeLabel(activity.start_time)}–{timeLabel(activity.end_time)}
+                          </h3>
+                          <p className="mt-2 whitespace-pre-line text-sm leading-6 text-slate-600 dark:text-slate-300">
+                            {activity.description}
+                          </p>
+
+                          {(activity.group_label || activity.teacher_name) ? (
+                            <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+                              {activity.group_label ? (
+                                <span className="rounded-lg bg-slate-100 px-2.5 py-1.5 dark:bg-slate-800">
+                                  {activity.group_label}
+                                </span>
+                              ) : null}
+                              {activity.teacher_name ? (
+                                <span className="rounded-lg bg-slate-100 px-2.5 py-1.5 dark:bg-slate-800">
+                                  {activity.teacher_name}
+                                </span>
+                              ) : null}
+                            </div>
                           ) : null}
-                          {activity.teacher_name ? (
-                            <p className="mt-1 text-slate-500 dark:text-slate-400">{activity.teacher_name}</p>
+
+                          {activity.notes ? (
+                            <div className="mt-4 border-t border-slate-100 pt-4 text-sm leading-6 text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                              {activity.notes}
+                            </div>
                           ) : null}
                         </div>
-                      ) : null}
-                    </div>
 
-                    {activity.notes ? (
-                      <div className="mt-4 border-t border-slate-100 pt-4 text-sm leading-6 text-slate-500 dark:border-slate-800 dark:text-slate-400">
-                        {activity.notes}
+                        {editable ? (
+                          <div className="flex shrink-0 gap-2">
+                            <Link
+                              href={`/activities/${activity.id}/edit`}
+                              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-300 px-4 text-sm font-bold text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                            >
+                              Editar
+                            </Link>
+                            <details className="relative">
+                              <summary className="flex h-10 cursor-pointer list-none items-center rounded-xl border border-rose-200 px-4 text-sm font-bold text-rose-700 transition hover:bg-rose-50 dark:border-rose-900 dark:text-rose-300 dark:hover:bg-rose-950/40">
+                                Excluir
+                              </summary>
+                              <div className="absolute right-0 z-10 mt-2 w-64 rounded-2xl border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+                                <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                                  Excluir esta atividade?
+                                </p>
+                                <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                                  As horas serão removidas do progresso. Esta ação não pode ser desfeita.
+                                </p>
+                                <form action={deleteAction} className="mt-3">
+                                  <button
+                                    type="submit"
+                                    className="inline-flex h-9 w-full items-center justify-center rounded-lg bg-rose-600 px-3 text-xs font-bold text-white hover:bg-rose-500"
+                                  >
+                                    Confirmar exclusão
+                                  </button>
+                                </form>
+                              </div>
+                            </details>
+                          </div>
+                        ) : (
+                          <span className="shrink-0 text-xs font-semibold text-slate-400">
+                            Registro bloqueado após revisão
+                          </span>
+                        )}
                       </div>
-                    ) : null}
-                  </article>
-                ))}
+                    </article>
+                  );
+                })}
               </div>
             )}
           </section>
         </>
       )}
+    </div>
+  );
+}
+
+const inputClass =
+  "mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white";
+const textareaClass =
+  "mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white";
+
+function Field({
+  label,
+  full = false,
+  children,
+}: {
+  label: string;
+  full?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className={full ? "block sm:col-span-2" : "block"}>
+      <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Metric({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p className="text-2xl font-bold text-slate-950 dark:text-white">{value}</p>
+      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{label}</p>
+    </div>
+  );
+}
+
+function Notice({
+  tone,
+  children,
+}: {
+  tone: "success" | "error";
+  children: React.ReactNode;
+}) {
+  const classes =
+    tone === "success"
+      ? "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200"
+      : "border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200";
+
+  return (
+    <div className={`rounded-2xl border p-4 text-sm font-semibold ${classes}`}>
+      {children}
     </div>
   );
 }

--- a/src/features/activities/actions/activity.actions.ts
+++ b/src/features/activities/actions/activity.actions.ts
@@ -64,7 +64,10 @@ export async function updateActivityAction(
   redirect("/activities?updated=1");
 }
 
-export async function deleteActivityAction(activityId: string) {
+export async function deleteActivityAction(
+  activityId: string,
+  _formData: FormData,
+) {
   const result = await deleteActivity(activityId);
 
   if (!result.ok) {

--- a/src/features/activities/actions/activity.actions.ts
+++ b/src/features/activities/actions/activity.actions.ts
@@ -3,11 +3,21 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
-import { createActivity } from "../repositories/activity.repository";
+import {
+  createActivity,
+  deleteActivity,
+  updateActivity,
+} from "../repositories/activity.repository";
 
 function field(formData: FormData, name: string) {
   const value = formData.get(name);
   return typeof value === "string" ? value : "";
+}
+
+function revalidateActivityViews() {
+  revalidatePath("/activities");
+  revalidatePath("/dashboard");
+  revalidatePath("/internships");
 }
 
 export async function createActivityAction(formData: FormData) {
@@ -27,8 +37,40 @@ export async function createActivityAction(formData: FormData) {
     redirect(`/activities?error=${reason}`);
   }
 
-  revalidatePath("/activities");
-  revalidatePath("/dashboard");
-  revalidatePath("/internships");
+  revalidateActivityViews();
   redirect("/activities?created=1");
+}
+
+export async function updateActivityAction(
+  activityId: string,
+  formData: FormData,
+) {
+  const result = await updateActivity(activityId, {
+    activityDate: field(formData, "activityDate"),
+    startTime: field(formData, "startTime"),
+    endTime: field(formData, "endTime"),
+    groupLabel: field(formData, "groupLabel"),
+    teacherName: field(formData, "teacherName"),
+    description: field(formData, "description"),
+    notes: field(formData, "notes"),
+  });
+
+  if (!result.ok) {
+    const reason = result.error.code === "invalid_activity_input" ? "invalid" : "locked";
+    redirect(`/activities/${activityId}/edit?error=${reason}`);
+  }
+
+  revalidateActivityViews();
+  redirect("/activities?updated=1");
+}
+
+export async function deleteActivityAction(activityId: string) {
+  const result = await deleteActivity(activityId);
+
+  if (!result.ok) {
+    redirect("/activities?error=delete");
+  }
+
+  revalidateActivityViews();
+  redirect("/activities?deleted=1");
 }

--- a/src/features/activities/index.ts
+++ b/src/features/activities/index.ts
@@ -1,8 +1,15 @@
-export { createActivityAction } from "./actions/activity.actions";
+export {
+  createActivityAction,
+  deleteActivityAction,
+  updateActivityAction,
+} from "./actions/activity.actions";
 export {
   createActivity,
+  deleteActivity,
+  getActivity,
   getActivitySummary,
   listActivities,
+  updateActivity,
 } from "./repositories/activity.repository";
 export type {
   ActivityError,

--- a/src/features/activities/repositories/activity.repository.ts
+++ b/src/features/activities/repositories/activity.repository.ts
@@ -1,11 +1,14 @@
 import type { PostgrestError } from "@supabase/supabase-js";
 
 import { createClient } from "@/lib/supabase/server";
-import type { TablesInsert } from "@/types/database";
+import type { TablesInsert, TablesUpdate } from "@/types/database";
 
 import {
+  activityIdSchema,
   createActivityInputSchema,
+  updateActivityInputSchema,
   type CreateActivityInput,
+  type UpdateActivityInput,
 } from "../schemas/activity.schema";
 import type {
   ActivityLog,
@@ -89,6 +92,35 @@ export async function createActivity(
   return { ok: true, data };
 }
 
+export async function getActivity(
+  activityId: string,
+): Promise<ActivityResult<ActivityLog | null>> {
+  const parsedId = activityIdSchema.safeParse(activityId);
+
+  if (!parsedId.success) {
+    return repositoryError("invalid_activity_id", "Atividade inválida.");
+  }
+
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("activity_logs")
+    .select(ACTIVITY_COLUMNS)
+    .eq("id", parsedId.data)
+    .eq("student_id", auth.userId)
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
 export async function listActivities(
   internshipId: string,
 ): Promise<ActivityResult<ActivityLog[]>> {
@@ -108,6 +140,101 @@ export async function listActivities(
 
   if (error) {
     return databaseError(error);
+  }
+
+  return { ok: true, data };
+}
+
+export async function updateActivity(
+  activityId: string,
+  input: UpdateActivityInput,
+): Promise<ActivityResult<ActivityLog>> {
+  const parsedId = activityIdSchema.safeParse(activityId);
+  const parsed = updateActivityInputSchema.safeParse(input);
+
+  if (!parsedId.success) {
+    return repositoryError("invalid_activity_id", "Atividade inválida.");
+  }
+
+  if (!parsed.success) {
+    return repositoryError(
+      "invalid_activity_input",
+      parsed.error.issues[0]?.message ?? "Dados da atividade inválidos.",
+    );
+  }
+
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const payload: TablesUpdate<"activity_logs"> = {
+    activity_date: parsed.data.activityDate,
+    start_time: parsed.data.startTime,
+    end_time: parsed.data.endTime,
+    group_label: parsed.data.groupLabel,
+    teacher_name: parsed.data.teacherName,
+    description: parsed.data.description,
+    notes: parsed.data.notes,
+  };
+
+  const { data, error } = await auth.supabase
+    .from("activity_logs")
+    .update(payload)
+    .eq("id", parsedId.data)
+    .eq("student_id", auth.userId)
+    .in("status", ["draft", "submitted"])
+    .select(ACTIVITY_COLUMNS)
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  if (!data) {
+    return repositoryError(
+      "activity_not_editable",
+      "A atividade não foi encontrada ou já foi revisada.",
+    );
+  }
+
+  return { ok: true, data };
+}
+
+export async function deleteActivity(
+  activityId: string,
+): Promise<ActivityResult<{ id: string }>> {
+  const parsedId = activityIdSchema.safeParse(activityId);
+
+  if (!parsedId.success) {
+    return repositoryError("invalid_activity_id", "Atividade inválida.");
+  }
+
+  const auth = await getAuthenticatedContext();
+
+  if (!auth.ok) {
+    return { ok: false, error: auth.error };
+  }
+
+  const { data, error } = await auth.supabase
+    .from("activity_logs")
+    .delete()
+    .eq("id", parsedId.data)
+    .eq("student_id", auth.userId)
+    .in("status", ["draft", "submitted"])
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  if (!data) {
+    return repositoryError(
+      "activity_not_deletable",
+      "A atividade não foi encontrada ou já foi revisada.",
+    );
   }
 
   return { ok: true, data };

--- a/src/features/activities/schemas/activity.schema.ts
+++ b/src/features/activities/schemas/activity.schema.ts
@@ -15,9 +15,8 @@ const optionalText = (max: number) =>
     .max(max)
     .transform((value) => (value.length > 0 ? value : null));
 
-export const createActivityInputSchema = z
+const activityFieldsSchema = z
   .object({
-    internshipId: z.uuid(),
     activityDate: z.string().regex(datePattern, "Informe uma data válida."),
     startTime: z.string().regex(timePattern, "Informe o horário inicial."),
     endTime: z.string().regex(timePattern, "Informe o horário final."),
@@ -38,4 +37,14 @@ export const createActivityInputSchema = z
     },
   );
 
+export const activityIdSchema = z.uuid();
+
+export const createActivityInputSchema = z.intersection(
+  z.object({ internshipId: z.uuid() }),
+  activityFieldsSchema,
+);
+
+export const updateActivityInputSchema = activityFieldsSchema;
+
 export type CreateActivityInput = z.infer<typeof createActivityInputSchema>;
+export type UpdateActivityInput = z.infer<typeof updateActivityInputSchema>;


### PR DESCRIPTION
Fecha o ciclo de manutenção de atividades pelo aluno.

Inclui:
- edição de atividades `draft`/`submitted`;
- exclusão de atividades não revisadas;
- recálculo automático de duração pelo trigger existente;
- bloqueio visual e de repository após revisão;
- feedback de criação/edição/exclusão;
- rota `/activities/[id]/edit`;
- dashboard e histórico revalidados após alterações.

Validação final: `npm ci`, lint, typecheck e build verdes.

Closes #46