### PR TITLE
feat: add advisor activity review workflow

### DIFF
--- a/src/app/(protected)/activities/page.tsx
+++ b/src/app/(protected)/activities/page.tsx
@@ -186,12 +186,7 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
                   <input required type="date" name="activityDate" className={inputClass} />
                 </Field>
                 <Field label="Turma / grupo">
-                  <input
-                    type="text"
-                    name="groupLabel"
-                    placeholder="Ex.: 8º ano A"
-                    className={inputClass}
-                  />
+                  <input type="text" name="groupLabel" placeholder="Ex.: 8º ano A" className={inputClass} />
                 </Field>
                 <Field label="Início">
                   <input required type="time" name="startTime" className={inputClass} />
@@ -200,38 +195,19 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
                   <input required type="time" name="endTime" className={inputClass} />
                 </Field>
                 <Field label="Professor / supervisor presente" full>
-                  <input
-                    type="text"
-                    name="teacherName"
-                    placeholder="Nome do professor acompanhado"
-                    className={inputClass}
-                  />
+                  <input type="text" name="teacherName" placeholder="Nome do professor acompanhado" className={inputClass} />
                 </Field>
                 <Field label="Descrição da atividade" full>
-                  <textarea
-                    required
-                    name="description"
-                    rows={4}
-                    placeholder="Descreva o que foi acompanhado ou realizado durante o estágio."
-                    className={textareaClass}
-                  />
+                  <textarea required name="description" rows={4} placeholder="Descreva o que foi acompanhado ou realizado durante o estágio." className={textareaClass} />
                 </Field>
                 <Field label="Observações" full>
-                  <textarea
-                    name="notes"
-                    rows={3}
-                    placeholder="Opcional: anotações, ocorrências ou pontos importantes."
-                    className={textareaClass}
-                  />
+                  <textarea name="notes" rows={3} placeholder="Opcional: anotações, ocorrências ou pontos importantes." className={textareaClass} />
                 </Field>
                 <div className="sm:col-span-2 flex flex-col gap-3 border-t border-slate-200 pt-5 sm:flex-row sm:items-center sm:justify-between dark:border-slate-800">
                   <p className="text-xs leading-5 text-slate-500 dark:text-slate-400">
                     O registro ficará pendente. Até a revisão, as horas aparecem como provisórias.
                   </p>
-                  <button
-                    type="submit"
-                    className="inline-flex h-12 shrink-0 items-center justify-center rounded-xl bg-indigo-600 px-6 text-sm font-bold text-white transition hover:bg-indigo-500"
-                  >
+                  <button type="submit" className="inline-flex h-12 shrink-0 items-center justify-center rounded-xl bg-indigo-600 px-6 text-sm font-bold text-white transition hover:bg-indigo-500">
                     Registrar atividade
                   </button>
                 </div>
@@ -243,20 +219,14 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
             <div className="flex items-end justify-between gap-4">
               <div>
                 <p className="text-sm font-semibold text-indigo-600 dark:text-indigo-400">Histórico</p>
-                <h2 className="mt-1 text-xl font-bold text-slate-950 dark:text-white">
-                  Atividades registradas
-                </h2>
+                <h2 className="mt-1 text-xl font-bold text-slate-950 dark:text-white">Atividades registradas</h2>
               </div>
-              <span className="text-sm text-slate-500 dark:text-slate-400">
-                {activities.length} registro(s)
-              </span>
+              <span className="text-sm text-slate-500 dark:text-slate-400">{activities.length} registro(s)</span>
             </div>
 
             {activities.length === 0 ? (
               <div className="mt-4 rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center dark:border-slate-700 dark:bg-slate-900">
-                <p className="font-semibold text-slate-900 dark:text-white">
-                  Nenhuma atividade registrada ainda.
-                </p>
+                <p className="font-semibold text-slate-900 dark:text-white">Nenhuma atividade registrada ainda.</p>
                 <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                   O primeiro registro aparecerá aqui e também alimentará seu dashboard.
                 </p>
@@ -264,90 +234,75 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
             ) : (
               <div className="mt-4 space-y-3">
                 {activities.map((activity) => {
-                  const editable =
-                    activity.status === "draft" || activity.status === "submitted";
+                  const editable = activity.status === "draft" || activity.status === "submitted";
                   const deleteAction = deleteActivityAction.bind(null, activity.id);
+                  const reviewed = activity.status === "approved" || activity.status === "rejected";
 
                   return (
-                    <article
-                      key={activity.id}
-                      className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
-                    >
+                    <article key={activity.id} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
                       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                         <div className="min-w-0 flex-1">
                           <div className="flex flex-wrap items-center gap-2">
-                            <span
-                              className={`rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider ${STATUS_STYLES[activity.status]}`}
-                            >
+                            <span className={`rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider ${STATUS_STYLES[activity.status]}`}>
                               {STATUS_LABELS[activity.status]}
                             </span>
-                            <span className="text-sm font-bold text-indigo-600 dark:text-indigo-400">
-                              {durationLabel(activity.duration_minutes)}
-                            </span>
+                            <span className="text-sm font-bold text-indigo-600 dark:text-indigo-400">{durationLabel(activity.duration_minutes)}</span>
                           </div>
                           <h3 className="mt-3 font-bold text-slate-950 dark:text-white">
                             {dateLabel(activity.activity_date)} · {timeLabel(activity.start_time)}–{timeLabel(activity.end_time)}
                           </h3>
-                          <p className="mt-2 whitespace-pre-line text-sm leading-6 text-slate-600 dark:text-slate-300">
-                            {activity.description}
-                          </p>
+                          <p className="mt-2 whitespace-pre-line text-sm leading-6 text-slate-600 dark:text-slate-300">{activity.description}</p>
 
-                          {(activity.group_label || activity.teacher_name) ? (
+                          {activity.group_label || activity.teacher_name ? (
                             <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
-                              {activity.group_label ? (
-                                <span className="rounded-lg bg-slate-100 px-2.5 py-1.5 dark:bg-slate-800">
-                                  {activity.group_label}
-                                </span>
-                              ) : null}
-                              {activity.teacher_name ? (
-                                <span className="rounded-lg bg-slate-100 px-2.5 py-1.5 dark:bg-slate-800">
-                                  {activity.teacher_name}
-                                </span>
-                              ) : null}
+                              {activity.group_label ? <span className="rounded-lg bg-slate-100 px-2.5 py-1.5 dark:bg-slate-800">{activity.group_label}</span> : null}
+                              {activity.teacher_name ? <span className="rounded-lg bg-slate-100 px-2.5 py-1.5 dark:bg-slate-800">{activity.teacher_name}</span> : null}
                             </div>
                           ) : null}
 
                           {activity.notes ? (
-                            <div className="mt-4 border-t border-slate-100 pt-4 text-sm leading-6 text-slate-500 dark:border-slate-800 dark:text-slate-400">
-                              {activity.notes}
+                            <div className="mt-4 border-t border-slate-100 pt-4 text-sm leading-6 text-slate-500 dark:border-slate-800 dark:text-slate-400">{activity.notes}</div>
+                          ) : null}
+
+                          {reviewed ? (
+                            <div className={`mt-4 rounded-2xl border p-4 ${activity.status === "approved" ? "border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/30" : "border-rose-200 bg-rose-50 dark:border-rose-900 dark:bg-rose-950/30"}`}>
+                              <p className={`text-sm font-bold ${activity.status === "approved" ? "text-emerald-900 dark:text-emerald-100" : "text-rose-900 dark:text-rose-100"}`}>
+                                {activity.status === "approved" ? "Atividade validada pelo orientador" : "Atividade não validada pelo orientador"}
+                              </p>
+                              {activity.review_comment ? (
+                                <p className={`mt-2 text-sm leading-6 ${activity.status === "approved" ? "text-emerald-800 dark:text-emerald-200" : "text-rose-800 dark:text-rose-200"}`}>
+                                  Parecer: {activity.review_comment}
+                                </p>
+                              ) : (
+                                <p className={`mt-2 text-sm ${activity.status === "approved" ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300"}`}>
+                                  Sem observações adicionais.
+                                </p>
+                              )}
+                              {activity.reviewed_at ? (
+                                <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                                  Revisado em {new Date(activity.reviewed_at).toLocaleString("pt-BR")}
+                                </p>
+                              ) : null}
                             </div>
                           ) : null}
                         </div>
 
                         {editable ? (
                           <div className="flex shrink-0 gap-2">
-                            <Link
-                              href={`/activities/${activity.id}/edit`}
-                              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-300 px-4 text-sm font-bold text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-                            >
-                              Editar
-                            </Link>
+                            <Link href={`/activities/${activity.id}/edit`} className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-300 px-4 text-sm font-bold text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">Editar</Link>
                             <details className="relative">
-                              <summary className="flex h-10 cursor-pointer list-none items-center rounded-xl border border-rose-200 px-4 text-sm font-bold text-rose-700 transition hover:bg-rose-50 dark:border-rose-900 dark:text-rose-300 dark:hover:bg-rose-950/40">
-                                Excluir
-                              </summary>
+                              <summary className="flex h-10 cursor-pointer list-none items-center rounded-xl border border-rose-200 px-4 text-sm font-bold text-rose-700 transition hover:bg-rose-50 dark:border-rose-900 dark:text-rose-300 dark:hover:bg-rose-950/40">Excluir</summary>
                               <div className="absolute right-0 z-10 mt-2 w-64 rounded-2xl border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-900">
-                                <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                                  Excluir esta atividade?
-                                </p>
-                                <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
-                                  As horas serão removidas do progresso. Esta ação não pode ser desfeita.
-                                </p>
+                                <p className="text-sm font-semibold text-slate-900 dark:text-white">Excluir esta atividade?</p>
+                                <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">As horas serão removidas do progresso. Esta ação não pode ser desfeita.</p>
                                 <form action={deleteAction} className="mt-3">
-                                  <button
-                                    type="submit"
-                                    className="inline-flex h-9 w-full items-center justify-center rounded-lg bg-rose-600 px-3 text-xs font-bold text-white hover:bg-rose-500"
-                                  >
-                                    Confirmar exclusão
-                                  </button>
+                                  <button type="submit" className="inline-flex h-9 w-full items-center justify-center rounded-lg bg-rose-600 px-3 text-xs font-bold text-white hover:bg-rose-500">Confirmar exclusão</button>
                                 </form>
                               </div>
                             </details>
                           </div>
                         ) : (
-                          <span className="shrink-0 text-xs font-semibold text-slate-400">
-                            Registro bloqueado após revisão
-                          </span>
+                          <span className="shrink-0 text-xs font-semibold text-slate-400">Registro bloqueado após revisão</span>
                         )}
                       </div>
                     </article>
@@ -362,20 +317,10 @@ export default async function ActivitiesPage({ searchParams }: ActivitiesPagePro
   );
 }
 
-const inputClass =
-  "mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white";
-const textareaClass =
-  "mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white";
+const inputClass = "mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white";
+const textareaClass = "mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white";
 
-function Field({
-  label,
-  full = false,
-  children,
-}: {
-  label: string;
-  full?: boolean;
-  children: React.ReactNode;
-}) {
+function Field({ label, full = false, children }: { label: string; full?: boolean; children: React.ReactNode }) {
   return (
     <label className={full ? "block sm:col-span-2" : "block"}>
       <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{label}</span>
@@ -393,21 +338,10 @@ function Metric({ value, label }: { value: string; label: string }) {
   );
 }
 
-function Notice({
-  tone,
-  children,
-}: {
-  tone: "success" | "error";
-  children: React.ReactNode;
-}) {
-  const classes =
-    tone === "success"
-      ? "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200"
-      : "border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200";
+function Notice({ tone, children }: { tone: "success" | "error"; children: React.ReactNode }) {
+  const classes = tone === "success"
+    ? "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200"
+    : "border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200";
 
-  return (
-    <div className={`rounded-2xl border p-4 text-sm font-semibold ${classes}`}>
-      {children}
-    </div>
-  );
+  return <div className={`rounded-2xl border p-4 text-sm font-semibold ${classes}`}>{children}</div>;
 }

--- a/src/app/(protected)/advisor/page.tsx
+++ b/src/app/(protected)/advisor/page.tsx
@@ -1,0 +1,154 @@
+import { redirect } from "next/navigation";
+
+import { getAdvisorWorkspace } from "@/features/advisor";
+import { PendingReviewCard } from "@/features/advisor/components/pending-review-card";
+import { ReviewedActivityCard } from "@/features/advisor/components/reviewed-activity-card";
+import type { ActivityStatusEvent } from "@/features/activities";
+
+type AdvisorPageProps = {
+  searchParams: Promise<{ reviewed?: string; error?: string }>;
+};
+
+export default async function AdvisorPage({ searchParams }: AdvisorPageProps) {
+  const params = await searchParams;
+  const result = await getAdvisorWorkspace();
+
+  if (!result.ok && result.error.code === "reviewer_role_required") {
+    redirect("/dashboard");
+  }
+
+  if (!result.ok) {
+    return (
+      <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8 dark:border-amber-900 dark:bg-amber-950/40">
+        <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">Revisões</p>
+        <h1 className="mt-2 text-2xl font-bold text-amber-950 dark:text-amber-50">
+          Não foi possível carregar sua fila agora.
+        </h1>
+      </section>
+    );
+  }
+
+  const workspace = result.data;
+  const eventsByActivity = new Map<string, ActivityStatusEvent[]>();
+
+  workspace.events.forEach((event) => {
+    const current = eventsByActivity.get(event.activity_id) ?? [];
+    current.push(event);
+    eventsByActivity.set(event.activity_id, current);
+  });
+
+  return (
+    <div className="space-y-7 sm:space-y-9">
+      {params.reviewed === "approved" ? (
+        <Notice tone="success">Atividade aprovada e registrada no histórico.</Notice>
+      ) : null}
+      {params.reviewed === "rejected" ? (
+        <Notice tone="success">Atividade rejeitada e retirada das horas contabilizadas.</Notice>
+      ) : null}
+      {params.error ? (
+        <Notice tone="error">
+          {params.error === "invalid"
+            ? "Para rejeitar uma atividade, informe uma justificativa com pelo menos 3 caracteres."
+            : "Esta atividade não está mais disponível para revisão ou não pertence a um estágio atribuído a você."}
+        </Notice>
+      ) : null}
+
+      <section>
+        <p className="text-sm font-semibold text-indigo-600 dark:text-indigo-400">Área do orientador</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950 dark:text-white">
+          Revisão de atividades
+        </h1>
+        <p className="mt-3 max-w-3xl text-base leading-7 text-slate-600 dark:text-slate-300">
+          Analise os registros dos estudantes formalmente atribuídos a você. Cada decisão fica preservada na trilha de histórico.
+        </p>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <Metric value={String(workspace.internships.length)} label="Estágios atribuídos" />
+        <Metric value={String(workspace.pending.length)} label="Aguardando revisão" />
+        <Metric value={String(workspace.reviewed.length)} label="Revisões recentes" />
+      </section>
+
+      {workspace.internships.length === 0 ? (
+        <section className="rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <h2 className="text-xl font-bold text-slate-950 dark:text-white">Nenhum estágio atribuído</h2>
+          <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+            Quando um estágio for vinculado ao seu perfil, as pendências aparecerão automaticamente aqui.
+          </p>
+        </section>
+      ) : (
+        <>
+          <section>
+            <SectionHeading label="Fila" title="Aguardando sua decisão" count={workspace.pending.length} />
+            {workspace.pending.length === 0 ? (
+              <div className="mt-4 rounded-3xl border border-dashed border-emerald-300 bg-emerald-50/70 p-8 text-center dark:border-emerald-900 dark:bg-emerald-950/30">
+                <p className="font-bold text-emerald-900 dark:text-emerald-100">Fila zerada.</p>
+                <p className="mt-2 text-sm text-emerald-700 dark:text-emerald-300">
+                  Não há atividades pendentes de validação neste momento.
+                </p>
+              </div>
+            ) : (
+              <div className="mt-4 space-y-4">
+                {workspace.pending.map((activity) => (
+                  <PendingReviewCard key={activity.id} activity={activity} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <SectionHeading label="Histórico" title="Revisões recentes" />
+            {workspace.reviewed.length === 0 ? (
+              <div className="mt-4 rounded-3xl border border-dashed border-slate-300 bg-white p-7 text-center dark:border-slate-700 dark:bg-slate-900">
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Suas primeiras aprovações e rejeições aparecerão aqui.
+                </p>
+              </div>
+            ) : (
+              <div className="mt-4 space-y-3">
+                {workspace.reviewed.map((activity) => (
+                  <ReviewedActivityCard
+                    key={activity.id}
+                    activity={activity}
+                    events={eventsByActivity.get(activity.id) ?? []}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Metric({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p className="text-2xl font-bold text-slate-950 dark:text-white">{value}</p>
+      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{label}</p>
+    </div>
+  );
+}
+
+function SectionHeading({ label, title, count }: { label: string; title: string; count?: number }) {
+  return (
+    <div className="flex flex-wrap items-end justify-between gap-3">
+      <div>
+        <p className="text-sm font-semibold text-indigo-600 dark:text-indigo-400">{label}</p>
+        <h2 className="mt-1 text-xl font-bold text-slate-950 dark:text-white">{title}</h2>
+      </div>
+      {count !== undefined ? (
+        <span className="text-sm text-slate-500 dark:text-slate-400">{count} pendência(s)</span>
+      ) : null}
+    </div>
+  );
+}
+
+function Notice({ tone, children }: { tone: "success" | "error"; children: React.ReactNode }) {
+  const classes = tone === "success"
+    ? "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200"
+    : "border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200";
+
+  return <div className={`rounded-2xl border p-4 text-sm font-semibold ${classes}`}>{children}</div>;
+}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -4,11 +4,12 @@ import { redirect } from "next/navigation";
 import { AuthenticatedHeader } from "@/features/navigation/components/authenticated-header";
 import { MobileNavigation } from "@/features/navigation/components/mobile-navigation";
 import { Sidebar } from "@/features/navigation/components/sidebar";
+import type { NavigationRole } from "@/features/navigation/config/authenticated-navigation";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
-function roleLabel(role: "student" | "advisor" | "coordinator" | undefined) {
+function roleLabel(role: NavigationRole) {
   switch (role) {
     case "advisor":
       return "Orientador";
@@ -39,13 +40,15 @@ export default async function ProtectedLayout({
 
   const email = typeof claims.email === "string" ? claims.email : null;
   const displayName = profile?.full_name ?? email ?? "Usuário StageTrack";
-  const currentRoleLabel = roleLabel(profile?.role);
+  const role: NavigationRole = profile?.role ?? "student";
+  const currentRoleLabel = roleLabel(role);
 
   return (
-    <div className="flex min-h-screen bg-slate-50 text-slate-950">
+    <div className="flex min-h-screen bg-slate-50 text-slate-950 dark:bg-slate-950 dark:text-slate-50">
       <Sidebar
         displayName={displayName}
         roleLabel={currentRoleLabel}
+        role={role}
         email={email}
       />
 
@@ -53,6 +56,7 @@ export default async function ProtectedLayout({
         <AuthenticatedHeader
           displayName={displayName}
           roleLabel={currentRoleLabel}
+          role={role}
         />
 
         <main className="mx-auto w-full max-w-7xl px-5 py-7 pb-28 sm:px-6 sm:py-8 lg:px-8 lg:py-10 lg:pb-10">
@@ -60,7 +64,7 @@ export default async function ProtectedLayout({
         </main>
       </div>
 
-      <MobileNavigation />
+      <MobileNavigation role={role} />
     </div>
   );
 }

--- a/src/features/activities/index.ts
+++ b/src/features/activities/index.ts
@@ -15,5 +15,6 @@ export type {
   ActivityError,
   ActivityLog,
   ActivityResult,
+  ActivityStatusEvent,
   ActivitySummary,
 } from "./types";

--- a/src/features/activities/repositories/activity.repository.ts
+++ b/src/features/activities/repositories/activity.repository.ts
@@ -16,15 +16,18 @@ import type {
   ActivitySummary,
 } from "../types";
 
-const ACTIVITY_COLUMNS =
-  "id,internship_id,student_id,activity_date,start_time,end_time,duration_minutes,group_label,teacher_name,description,notes,status,created_at,updated_at" as const;
-
 function repositoryError(code: string, message: string): ActivityResult<never> {
   return { ok: false, error: { code, message } };
 }
 
 function databaseError(error: PostgrestError): ActivityResult<never> {
   return repositoryError(error.code, error.message);
+}
+
+function withReviewMetadata<T>(data: T) {
+  return data as unknown as T extends Array<unknown>
+    ? ActivityLog[]
+    : ActivityLog;
 }
 
 async function getAuthenticatedContext() {
@@ -74,22 +77,20 @@ export async function createActivity(
     notes: parsed.data.notes,
   };
 
-  // `student_id`, `duration_minutes` and `status` are protected and prepared
-  // by PostgreSQL. Generated types cannot infer values populated by triggers.
   const insertPayload =
     clientPayload as unknown as TablesInsert<"activity_logs">;
 
   const { data, error } = await auth.supabase
     .from("activity_logs")
     .insert(insertPayload)
-    .select(ACTIVITY_COLUMNS)
+    .select("*")
     .single();
 
   if (error) {
     return databaseError(error);
   }
 
-  return { ok: true, data };
+  return { ok: true, data: withReviewMetadata(data) };
 }
 
 export async function getActivity(
@@ -109,7 +110,7 @@ export async function getActivity(
 
   const { data, error } = await auth.supabase
     .from("activity_logs")
-    .select(ACTIVITY_COLUMNS)
+    .select("*")
     .eq("id", parsedId.data)
     .eq("student_id", auth.userId)
     .maybeSingle();
@@ -118,7 +119,7 @@ export async function getActivity(
     return databaseError(error);
   }
 
-  return { ok: true, data };
+  return { ok: true, data: data ? withReviewMetadata(data) : null };
 }
 
 export async function listActivities(
@@ -132,7 +133,7 @@ export async function listActivities(
 
   const { data, error } = await auth.supabase
     .from("activity_logs")
-    .select(ACTIVITY_COLUMNS)
+    .select("*")
     .eq("internship_id", internshipId)
     .eq("student_id", auth.userId)
     .order("activity_date", { ascending: false })
@@ -142,7 +143,7 @@ export async function listActivities(
     return databaseError(error);
   }
 
-  return { ok: true, data };
+  return { ok: true, data: withReviewMetadata(data) };
 }
 
 export async function updateActivity(
@@ -185,7 +186,7 @@ export async function updateActivity(
     .eq("id", parsedId.data)
     .eq("student_id", auth.userId)
     .in("status", ["draft", "submitted"])
-    .select(ACTIVITY_COLUMNS)
+    .select("*")
     .maybeSingle();
 
   if (error) {
@@ -199,7 +200,7 @@ export async function updateActivity(
     );
   }
 
-  return { ok: true, data };
+  return { ok: true, data: withReviewMetadata(data) };
 }
 
 export async function deleteActivity(

--- a/src/features/activities/types.ts
+++ b/src/features/activities/types.ts
@@ -1,6 +1,22 @@
 import type { Tables } from "@/types/database";
 
-export type ActivityLog = Tables<"activity_logs">;
+export type ActivityLog = Tables<"activity_logs"> & {
+  review_comment: string | null;
+  reviewed_at: string | null;
+  reviewed_by: string | null;
+};
+
+export type ActivityStatusEvent = {
+  id: string;
+  activity_id: string;
+  internship_id: string;
+  student_id: string;
+  actor_id: string;
+  from_status: ActivityLog["status"] | null;
+  to_status: ActivityLog["status"];
+  comment: string | null;
+  created_at: string;
+};
 
 export type ActivityError = {
   code: string;

--- a/src/features/advisor/actions/activity-review.actions.ts
+++ b/src/features/advisor/actions/activity-review.actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { reviewActivity } from "../repositories/activity-review.repository";
+
+function field(formData: FormData, name: string) {
+  const value = formData.get(name);
+  return typeof value === "string" ? value : "";
+}
+
+export async function reviewActivityAction(formData: FormData) {
+  const decision = field(formData, "decision");
+  const result = await reviewActivity({
+    activityId: field(formData, "activityId"),
+    decision: decision === "rejected" ? "rejected" : "approved",
+    comment: field(formData, "comment"),
+  });
+
+  if (!result.ok) {
+    const reason =
+      result.error.code === "invalid_review_input" ? "invalid" : "not-reviewable";
+    redirect(`/advisor?error=${reason}`);
+  }
+
+  revalidatePath("/advisor");
+  revalidatePath("/activities");
+  revalidatePath("/dashboard");
+  revalidatePath("/internships");
+  redirect(`/advisor?reviewed=${result.data.status}`);
+}

--- a/src/features/advisor/components/pending-review-card.tsx
+++ b/src/features/advisor/components/pending-review-card.tsx
@@ -1,0 +1,95 @@
+import { reviewActivityAction } from "../actions/activity-review.actions";
+import type { ReviewQueueItem } from "../types";
+
+function durationLabel(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining === 0
+    ? `${hours}h`
+    : `${hours}h${String(remaining).padStart(2, "0")}`;
+}
+
+function dateLabel(date: string) {
+  return new Date(`${date}T12:00:00`).toLocaleDateString("pt-BR");
+}
+
+export function PendingReviewCard({ activity }: { activity: ReviewQueueItem }) {
+  return (
+    <article className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6 dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-amber-100 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+              Pendente
+            </span>
+            <span className="text-sm font-bold text-indigo-600 dark:text-indigo-400">
+              {durationLabel(activity.duration_minutes)}
+            </span>
+          </div>
+
+          <h3 className="mt-3 text-lg font-bold text-slate-950 dark:text-white">
+            {activity.internship.studentName}
+          </h3>
+          <p className="mt-1 text-xs font-medium text-slate-500 dark:text-slate-400">
+            {activity.internship.internshipTypeName} · {activity.internship.organizationName}
+            {activity.internship.registrationNumber
+              ? ` · ${activity.internship.registrationNumber}`
+              : ""}
+          </p>
+
+          <p className="mt-4 text-sm font-semibold text-slate-800 dark:text-slate-200">
+            {dateLabel(activity.activity_date)} · {activity.start_time.slice(0, 5)}–{activity.end_time.slice(0, 5)}
+          </p>
+          <p className="mt-2 whitespace-pre-line text-sm leading-6 text-slate-600 dark:text-slate-300">
+            {activity.description}
+          </p>
+
+          {activity.group_label || activity.teacher_name || activity.notes ? (
+            <div className="mt-4 rounded-2xl bg-slate-50 p-4 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+              {activity.group_label ? <p>Turma: {activity.group_label}</p> : null}
+              {activity.teacher_name ? <p>Professor: {activity.teacher_name}</p> : null}
+              {activity.notes ? <p className="mt-2">Observações: {activity.notes}</p> : null}
+            </div>
+          ) : null}
+        </div>
+
+        <form
+          action={reviewActivityAction}
+          className="w-full rounded-2xl border border-slate-200 bg-slate-50 p-4 lg:w-80 dark:border-slate-700 dark:bg-slate-950"
+        >
+          <input type="hidden" name="activityId" value={activity.id} />
+          <label className="block">
+            <span className="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+              Parecer / justificativa
+            </span>
+            <textarea
+              name="comment"
+              rows={4}
+              maxLength={2000}
+              placeholder="Opcional para aprovação; obrigatório para rejeição."
+              className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-900 dark:text-white"
+            />
+          </label>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <button
+              type="submit"
+              name="decision"
+              value="rejected"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm font-bold text-rose-700 transition hover:bg-rose-50 dark:border-rose-900 dark:bg-slate-900 dark:text-rose-300 dark:hover:bg-rose-950/40"
+            >
+              Rejeitar
+            </button>
+            <button
+              type="submit"
+              name="decision"
+              value="approved"
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-emerald-600 px-3 text-sm font-bold text-white transition hover:bg-emerald-500"
+            >
+              Aprovar
+            </button>
+          </div>
+        </form>
+      </div>
+    </article>
+  );
+}

--- a/src/features/advisor/components/reviewed-activity-card.tsx
+++ b/src/features/advisor/components/reviewed-activity-card.tsx
@@ -1,0 +1,85 @@
+import type { ActivityStatusEvent } from "@/features/activities";
+
+import type { ReviewQueueItem } from "../types";
+
+const STATUS_LABELS = {
+  draft: "Rascunho",
+  submitted: "Pendente",
+  approved: "Aprovada",
+  rejected: "Rejeitada",
+} as const;
+
+function durationLabel(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining === 0
+    ? `${hours}h`
+    : `${hours}h${String(remaining).padStart(2, "0")}`;
+}
+
+function dateLabel(date: string) {
+  return new Date(`${date}T12:00:00`).toLocaleDateString("pt-BR");
+}
+
+function eventDateLabel(date: string) {
+  return new Date(date).toLocaleString("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+export function ReviewedActivityCard({
+  activity,
+  events,
+}: {
+  activity: ReviewQueueItem;
+  events: ActivityStatusEvent[];
+}) {
+  const approved = activity.status === "approved";
+  const orderedEvents = [...events].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  );
+
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider ${
+                approved
+                  ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
+                  : "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-200"
+              }`}
+            >
+              {STATUS_LABELS[activity.status]}
+            </span>
+            <span className="text-xs text-slate-400">
+              {activity.reviewed_at ? eventDateLabel(activity.reviewed_at) : ""}
+            </span>
+          </div>
+          <h3 className="mt-2 font-bold text-slate-950 dark:text-white">
+            {activity.internship.studentName} · {dateLabel(activity.activity_date)}
+          </h3>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            {durationLabel(activity.duration_minutes)} · {activity.description}
+          </p>
+          {activity.review_comment ? (
+            <p className="mt-3 rounded-xl bg-slate-50 px-3 py-2 text-sm leading-6 text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+              Parecer: {activity.review_comment}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="shrink-0 text-right text-xs text-slate-400">
+          {orderedEvents.map((event, index) => (
+            <p key={event.id} className={index > 0 ? "mt-1" : ""}>
+              {event.from_status ? `${STATUS_LABELS[event.from_status]} → ` : ""}
+              {STATUS_LABELS[event.to_status]}
+            </p>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/features/advisor/index.ts
+++ b/src/features/advisor/index.ts
@@ -1,0 +1,13 @@
+export { reviewActivityAction } from "./actions/activity-review.actions";
+export {
+  getAdvisorWorkspace,
+  reviewActivity,
+} from "./repositories/activity-review.repository";
+export type {
+  AdvisorError,
+  AdvisorResult,
+  AdvisorWorkspace,
+  AssignedInternshipSummary,
+  ReviewerRole,
+  ReviewQueueItem,
+} from "./types";

--- a/src/features/advisor/repositories/activity-review.repository.ts
+++ b/src/features/advisor/repositories/activity-review.repository.ts
@@ -1,0 +1,235 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import type {
+  ActivityLog,
+  ActivityStatusEvent,
+} from "@/features/activities";
+import { createClient } from "@/lib/supabase/server";
+import type { TablesUpdate } from "@/types/database";
+
+import {
+  activityReviewInputSchema,
+  type ActivityReviewInput,
+} from "../schemas/activity-review.schema";
+import type {
+  AdvisorResult,
+  AdvisorWorkspace,
+  AssignedInternshipSummary,
+  ReviewQueueItem,
+  ReviewerRole,
+} from "../types";
+
+function repositoryError(code: string, message: string): AdvisorResult<never> {
+  return { ok: false, error: { code, message } };
+}
+
+function databaseError(error: PostgrestError): AdvisorResult<never> {
+  return repositoryError(error.code, error.message);
+}
+
+async function getReviewerContext() {
+  const supabase = await createClient();
+  const { data: claimsData, error: claimsError } = await supabase.auth.getClaims();
+  const userId = claimsData?.claims?.sub;
+
+  if (claimsError || !userId) {
+    return {
+      ok: false as const,
+      error: {
+        code: claimsError?.code ?? "not_authenticated",
+        message: claimsError?.message ?? "Usuário autenticado é obrigatório.",
+      },
+    };
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("full_name,role")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (profileError) {
+    return { ok: false as const, error: profileError };
+  }
+
+  if (!profile || (profile.role !== "advisor" && profile.role !== "coordinator")) {
+    return {
+      ok: false as const,
+      error: {
+        code: "reviewer_role_required",
+        message: "Esta área é exclusiva para orientadores e coordenadores.",
+      },
+    };
+  }
+
+  return {
+    ok: true as const,
+    supabase,
+    userId,
+    reviewerName: profile.full_name,
+    role: profile.role as ReviewerRole,
+  };
+}
+
+type RawAssignedInternship = {
+  id: string;
+  student_id: string;
+  status: AssignedInternshipSummary["status"];
+  student: {
+    full_name: string;
+    registration_number: string | null;
+  } | null;
+  internship_types: { name: string } | null;
+  organizations: { name: string } | null;
+};
+
+function mapAssignedInternship(
+  internship: RawAssignedInternship,
+): AssignedInternshipSummary {
+  return {
+    id: internship.id,
+    studentId: internship.student_id,
+    studentName: internship.student?.full_name ?? "Estudante",
+    registrationNumber: internship.student?.registration_number ?? null,
+    internshipTypeName: internship.internship_types?.name ?? "Estágio",
+    organizationName: internship.organizations?.name ?? "Concedente não informada",
+    status: internship.status,
+  };
+}
+
+export async function getAdvisorWorkspace(): Promise<
+  AdvisorResult<AdvisorWorkspace>
+> {
+  const context = await getReviewerContext();
+
+  if (!context.ok) {
+    return { ok: false, error: context.error };
+  }
+
+  const { data: internshipRows, error: internshipError } = await context.supabase
+    .from("internships")
+    .select(
+      "id,student_id,status,student:profiles!internships_student_id_fkey(full_name,registration_number),internship_types(name),organizations(name)",
+    )
+    .eq("advisor_id", context.userId)
+    .neq("student_id", context.userId)
+    .order("created_at", { ascending: false });
+
+  if (internshipError) {
+    return databaseError(internshipError);
+  }
+
+  const internships = (internshipRows as unknown as RawAssignedInternship[]).map(
+    mapAssignedInternship,
+  );
+  const internshipIds = internships.map((internship) => internship.id);
+
+  if (internshipIds.length === 0) {
+    return {
+      ok: true,
+      data: {
+        reviewerName: context.reviewerName,
+        role: context.role,
+        internships: [],
+        pending: [],
+        reviewed: [],
+        events: [],
+      },
+    };
+  }
+
+  const [{ data: activityRows, error: activityError }, eventResult] =
+    await Promise.all([
+      context.supabase
+        .from("activity_logs")
+        .select("*")
+        .in("internship_id", internshipIds)
+        .order("activity_date", { ascending: false })
+        .order("start_time", { ascending: false }),
+      context.supabase
+        .from("activity_status_events" as "activity_logs")
+        .select("*")
+        .in("internship_id", internshipIds)
+        .order("created_at", { ascending: false }),
+    ]);
+
+  if (activityError) {
+    return databaseError(activityError);
+  }
+
+  if (eventResult.error) {
+    return databaseError(eventResult.error);
+  }
+
+  const internshipById = new Map(
+    internships.map((internship) => [internship.id, internship]),
+  );
+  const activities = activityRows as unknown as ActivityLog[];
+  const workspaceItems = activities.flatMap<ReviewQueueItem>((activity) => {
+    const internship = internshipById.get(activity.internship_id);
+    return internship ? [{ ...activity, internship }] : [];
+  });
+
+  return {
+    ok: true,
+    data: {
+      reviewerName: context.reviewerName,
+      role: context.role,
+      internships,
+      pending: workspaceItems.filter((activity) => activity.status === "submitted"),
+      reviewed: workspaceItems
+        .filter(
+          (activity) =>
+            activity.status === "approved" || activity.status === "rejected",
+        )
+        .slice(0, 20),
+      events: eventResult.data as unknown as ActivityStatusEvent[],
+    },
+  };
+}
+
+export async function reviewActivity(
+  input: ActivityReviewInput,
+): Promise<AdvisorResult<ActivityLog>> {
+  const parsed = activityReviewInputSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return repositoryError(
+      "invalid_review_input",
+      parsed.error.issues[0]?.message ?? "Revisão inválida.",
+    );
+  }
+
+  const context = await getReviewerContext();
+
+  if (!context.ok) {
+    return { ok: false, error: context.error };
+  }
+
+  const payload = {
+    status: parsed.data.decision,
+    review_comment: parsed.data.comment.length > 0 ? parsed.data.comment : null,
+  } as unknown as TablesUpdate<"activity_logs">;
+
+  const { data, error } = await context.supabase
+    .from("activity_logs")
+    .update(payload)
+    .eq("id", parsed.data.activityId)
+    .eq("status", "submitted")
+    .neq("student_id", context.userId)
+    .select("*")
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  if (!data) {
+    return repositoryError(
+      "activity_not_reviewable",
+      "A atividade não está pendente ou não pertence a um estágio atribuído a você.",
+    );
+  }
+
+  return { ok: true, data: data as unknown as ActivityLog };
+}

--- a/src/features/advisor/schemas/activity-review.schema.ts
+++ b/src/features/advisor/schemas/activity-review.schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const activityReviewInputSchema = z
+  .object({
+    activityId: z.uuid(),
+    decision: z.enum(["approved", "rejected"]),
+    comment: z.string().trim().max(2000),
+  })
+  .superRefine((value, context) => {
+    if (value.decision === "rejected" && value.comment.length < 3) {
+      context.addIssue({
+        code: "custom",
+        path: ["comment"],
+        message: "Informe uma justificativa para rejeitar a atividade.",
+      });
+    }
+  });
+
+export type ActivityReviewInput = z.infer<typeof activityReviewInputSchema>;

--- a/src/features/advisor/types.ts
+++ b/src/features/advisor/types.ts
@@ -1,0 +1,35 @@
+import type { ActivityLog, ActivityStatusEvent } from "@/features/activities";
+
+export type ReviewerRole = "advisor" | "coordinator";
+
+export type AssignedInternshipSummary = {
+  id: string;
+  studentId: string;
+  studentName: string;
+  registrationNumber: string | null;
+  internshipTypeName: string;
+  organizationName: string;
+  status: "draft" | "active" | "paused" | "completed" | "cancelled";
+};
+
+export type ReviewQueueItem = ActivityLog & {
+  internship: AssignedInternshipSummary;
+};
+
+export type AdvisorWorkspace = {
+  reviewerName: string;
+  role: ReviewerRole;
+  internships: AssignedInternshipSummary[];
+  pending: ReviewQueueItem[];
+  reviewed: ReviewQueueItem[];
+  events: ActivityStatusEvent[];
+};
+
+export type AdvisorError = {
+  code: string;
+  message: string;
+};
+
+export type AdvisorResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: AdvisorError };

--- a/src/features/navigation/components/authenticated-header.tsx
+++ b/src/features/navigation/components/authenticated-header.tsx
@@ -5,11 +5,15 @@ import { usePathname } from "next/navigation";
 
 import { logoutAction } from "@/features/auth/actions/auth.actions";
 
-import { findActiveNavigationItem } from "../config/authenticated-navigation";
+import {
+  findActiveNavigationItem,
+  type NavigationRole,
+} from "../config/authenticated-navigation";
 
 type AuthenticatedHeaderProps = {
   displayName: string;
   roleLabel: string;
+  role: NavigationRole;
 };
 
 function initials(name: string) {
@@ -24,18 +28,20 @@ function initials(name: string) {
 export function AuthenticatedHeader({
   displayName,
   roleLabel,
+  role,
 }: AuthenticatedHeaderProps) {
   const pathname = usePathname();
-  const activeItem = findActiveNavigationItem(pathname);
+  const activeItem = findActiveNavigationItem(pathname, role);
+  const homeHref = role === "student" ? "/dashboard" : "/advisor";
 
   return (
     <header className="sticky top-0 z-30 border-b border-slate-200/80 bg-white/90 backdrop-blur-xl dark:border-slate-800/80 dark:bg-slate-950/90">
       <div className="flex min-h-18 items-center justify-between gap-4 px-5 py-3 sm:px-6 lg:min-h-20 lg:px-8">
         <div className="flex min-w-0 items-center gap-3">
           <Link
-            href="/dashboard"
+            href={homeHref}
             className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-indigo-600 text-xs font-black text-white shadow-sm shadow-indigo-200 dark:shadow-none lg:hidden"
-            aria-label="Ir para o dashboard"
+            aria-label="Ir para a página inicial da área autenticada"
           >
             ST
           </Link>

--- a/src/features/navigation/components/mobile-navigation.tsx
+++ b/src/features/navigation/components/mobile-navigation.tsx
@@ -4,21 +4,24 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import {
-  authenticatedNavigation,
+  getAuthenticatedNavigation,
   isNavigationItemActive,
+  type NavigationRole,
 } from "../config/authenticated-navigation";
 import { NavigationIcon } from "./navigation-icon";
 
-export function MobileNavigation() {
+export function MobileNavigation({ role }: { role: NavigationRole }) {
   const pathname = usePathname();
+  const navigation = getAuthenticatedNavigation(role);
+  const gridClass = navigation.length === 2 ? "grid-cols-2" : "grid-cols-4";
 
   return (
     <nav
       aria-label="Navegação principal mobile"
-      className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 px-2 pt-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-[0_-8px_30px_rgba(15,23,42,0.06)] backdrop-blur-xl lg:hidden"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 px-2 pt-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-[0_-8px_30px_rgba(15,23,42,0.06)] backdrop-blur-xl lg:hidden dark:border-slate-800 dark:bg-slate-950/95"
     >
-      <div className="mx-auto grid max-w-lg grid-cols-4 gap-1">
-        {authenticatedNavigation.map((item) => {
+      <div className={`mx-auto grid max-w-lg ${gridClass} gap-1`}>
+        {navigation.map((item) => {
           const active = isNavigationItemActive(pathname, item.href);
 
           return (
@@ -28,8 +31,8 @@ export function MobileNavigation() {
               aria-current={active ? "page" : undefined}
               className={`flex min-w-0 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-bold transition ${
                 active
-                  ? "bg-indigo-50 text-indigo-700"
-                  : "text-slate-500 hover:bg-slate-50 hover:text-slate-900"
+                  ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-950/70 dark:text-indigo-200"
+                  : "text-slate-500 hover:bg-slate-50 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-900 dark:hover:text-white"
               }`}
             >
               <NavigationIcon

--- a/src/features/navigation/components/navigation-icon.tsx
+++ b/src/features/navigation/components/navigation-icon.tsx
@@ -40,6 +40,15 @@ export function NavigationIcon({
           <path d="M8 18h4.5" />
         </svg>
       );
+    case "review":
+      return (
+        <svg {...common}>
+          <path d="M7 3.5h8l3 3V20a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4.5a1 1 0 0 1 1-1Z" />
+          <path d="M15 3.5V7h3.5" />
+          <path d="m9 13 2 2 4-4" />
+          <path d="M9 18h6" />
+        </svg>
+      );
     case "profile":
       return (
         <svg {...common}>

--- a/src/features/navigation/components/sidebar.tsx
+++ b/src/features/navigation/components/sidebar.tsx
@@ -6,14 +6,16 @@ import { usePathname } from "next/navigation";
 import { logoutAction } from "@/features/auth/actions/auth.actions";
 
 import {
-  authenticatedNavigation,
+  getAuthenticatedNavigation,
   isNavigationItemActive,
+  type NavigationRole,
 } from "../config/authenticated-navigation";
 import { NavigationIcon } from "./navigation-icon";
 
 type SidebarProps = {
   displayName: string;
   roleLabel: string;
+  role: NavigationRole;
   email: string | null;
 };
 
@@ -26,21 +28,22 @@ function initials(name: string) {
     .join("") || "ST";
 }
 
-export function Sidebar({ displayName, roleLabel, email }: SidebarProps) {
+export function Sidebar({ displayName, roleLabel, role, email }: SidebarProps) {
   const pathname = usePathname();
+  const navigation = getAuthenticatedNavigation(role);
 
   return (
-    <aside className="hidden h-screen w-72 shrink-0 border-r border-slate-200 bg-white lg:sticky lg:top-0 lg:flex lg:flex-col">
-      <div className="border-b border-slate-100 px-6 py-7">
-        <Link href="/dashboard" className="inline-flex items-center gap-3 group">
-          <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-indigo-600 text-sm font-black tracking-tight text-white shadow-sm shadow-indigo-200 transition group-hover:bg-indigo-500">
+    <aside className="hidden h-screen w-72 shrink-0 border-r border-slate-200 bg-white lg:sticky lg:top-0 lg:flex lg:flex-col dark:border-slate-800 dark:bg-slate-950">
+      <div className="border-b border-slate-100 px-6 py-7 dark:border-slate-800">
+        <Link href={role === "student" ? "/dashboard" : "/advisor"} className="inline-flex items-center gap-3 group">
+          <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-indigo-600 text-sm font-black tracking-tight text-white shadow-sm shadow-indigo-200 transition group-hover:bg-indigo-500 dark:shadow-none">
             ST
           </span>
           <span>
-            <span className="block text-base font-black tracking-tight text-slate-950">
+            <span className="block text-base font-black tracking-tight text-slate-950 dark:text-white">
               StageTrack
             </span>
-            <span className="block text-xs font-medium text-slate-500">
+            <span className="block text-xs font-medium text-slate-500 dark:text-slate-400">
               Gestão de estágio
             </span>
           </span>
@@ -53,7 +56,7 @@ export function Sidebar({ displayName, roleLabel, email }: SidebarProps) {
         </p>
 
         <div className="mt-3 space-y-1.5">
-          {authenticatedNavigation.map((item) => {
+          {navigation.map((item) => {
             const active = isNavigationItemActive(pathname, item.href);
 
             return (
@@ -63,15 +66,15 @@ export function Sidebar({ displayName, roleLabel, email }: SidebarProps) {
                 aria-current={active ? "page" : undefined}
                 className={`group flex items-center gap-3 rounded-2xl px-3 py-3 transition ${
                   active
-                    ? "bg-indigo-50 text-indigo-700 shadow-sm ring-1 ring-inset ring-indigo-100"
-                    : "text-slate-600 hover:bg-slate-50 hover:text-slate-950"
+                    ? "bg-indigo-50 text-indigo-700 shadow-sm ring-1 ring-inset ring-indigo-100 dark:bg-indigo-950/60 dark:text-indigo-200 dark:ring-indigo-900"
+                    : "text-slate-600 hover:bg-slate-50 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-slate-900 dark:hover:text-white"
                 }`}
               >
                 <span
                   className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition ${
                     active
-                      ? "bg-white text-indigo-600 shadow-sm"
-                      : "bg-slate-50 text-slate-500 group-hover:bg-white group-hover:text-slate-700"
+                      ? "bg-white text-indigo-600 shadow-sm dark:bg-slate-900 dark:text-indigo-300"
+                      : "bg-slate-50 text-slate-500 group-hover:bg-white group-hover:text-slate-700 dark:bg-slate-900 dark:text-slate-400 dark:group-hover:bg-slate-800 dark:group-hover:text-slate-200"
                   }`}
                 >
                   <NavigationIcon name={item.icon} />
@@ -81,7 +84,7 @@ export function Sidebar({ displayName, roleLabel, email }: SidebarProps) {
                   <span className="block text-sm font-bold">{item.label}</span>
                   <span
                     className={`mt-0.5 block truncate text-xs ${
-                      active ? "text-indigo-500" : "text-slate-400"
+                      active ? "text-indigo-500 dark:text-indigo-300" : "text-slate-400"
                     }`}
                   >
                     {item.description}
@@ -93,15 +96,15 @@ export function Sidebar({ displayName, roleLabel, email }: SidebarProps) {
         </div>
       </nav>
 
-      <div className="border-t border-slate-100 p-4">
-        <div className="rounded-2xl bg-slate-50 p-3.5">
+      <div className="border-t border-slate-100 p-4 dark:border-slate-800">
+        <div className="rounded-2xl bg-slate-50 p-3.5 dark:bg-slate-900">
           <div className="flex items-center gap-3">
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-900 text-xs font-bold text-white">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-900 text-xs font-bold text-white dark:bg-slate-100 dark:text-slate-950">
               {initials(displayName)}
             </span>
             <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-bold text-slate-900">{displayName}</p>
-              <p className="truncate text-xs text-slate-500">
+              <p className="truncate text-sm font-bold text-slate-900 dark:text-white">{displayName}</p>
+              <p className="truncate text-xs text-slate-500 dark:text-slate-400">
                 {roleLabel}{email ? ` · ${email}` : ""}
               </p>
             </div>
@@ -110,7 +113,7 @@ export function Sidebar({ displayName, roleLabel, email }: SidebarProps) {
           <form action={logoutAction} className="mt-3">
             <button
               type="submit"
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-100 hover:text-slate-950"
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-100 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-800 dark:hover:text-white"
             >
               Sair da conta
             </button>

--- a/src/features/navigation/config/authenticated-navigation.ts
+++ b/src/features/navigation/config/authenticated-navigation.ts
@@ -2,7 +2,10 @@ export type NavigationIconName =
   | "dashboard"
   | "internship"
   | "activities"
+  | "review"
   | "profile";
+
+export type NavigationRole = "student" | "advisor" | "coordinator";
 
 export type AuthenticatedNavigationItem = {
   href: string;
@@ -12,7 +15,7 @@ export type AuthenticatedNavigationItem = {
   icon: NavigationIconName;
 };
 
-export const authenticatedNavigation = [
+const studentNavigation = [
   {
     href: "/dashboard",
     label: "Dashboard",
@@ -43,12 +46,33 @@ export const authenticatedNavigation = [
   },
 ] as const satisfies readonly AuthenticatedNavigationItem[];
 
+const reviewerNavigation = [
+  {
+    href: "/advisor",
+    label: "Revisões",
+    mobileLabel: "Revisões",
+    description: "Fila de atividades dos seus estudantes",
+    icon: "review",
+  },
+  {
+    href: "/profile",
+    label: "Perfil",
+    mobileLabel: "Perfil",
+    description: "Dados acadêmicos e da conta",
+    icon: "profile",
+  },
+] as const satisfies readonly AuthenticatedNavigationItem[];
+
+export function getAuthenticatedNavigation(role: NavigationRole) {
+  return role === "student" ? studentNavigation : reviewerNavigation;
+}
+
 export function isNavigationItemActive(pathname: string, href: string) {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
-export function findActiveNavigationItem(pathname: string) {
-  return authenticatedNavigation.find((item) =>
+export function findActiveNavigationItem(pathname: string, role: NavigationRole) {
+  return getAuthenticatedNavigation(role).find((item) =>
     isNavigationItemActive(pathname, item.href),
   );
 }

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -7,6 +7,7 @@ const PRIVATE_ROUTE_PREFIXES = [
   "/dashboard",
   "/internships",
   "/activities",
+  "/advisor",
   "/profile",
 ] as const;
 
@@ -87,8 +88,6 @@ export async function updateSession(request: NextRequest) {
     },
   });
 
-  // Keep this call immediately after client creation. getClaims validates the
-  // JWT and may refresh the cookie-backed session through @supabase/ssr.
   const { data, error } = await supabase.auth.getClaims();
   const isAuthenticated = !error && Boolean(data?.claims?.sub);
   const pathname = request.nextUrl.pathname;

--- a/supabase/migrations/20260902225216_add_advisor_activity_review.sql
+++ b/supabase/migrations/20260902225216_add_advisor_activity_review.sql
@@ -1,0 +1,366 @@
+create schema if not exists private;
+revoke all on schema private from public, anon, authenticated;
+
+alter table public.internships
+  add constraint internships_advisor_not_student
+  check (advisor_id is null or advisor_id <> student_id);
+
+create or replace function public.validate_internship_advisor_assignment()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  selected_role public.app_role;
+begin
+  if new.advisor_id is null then
+    return new;
+  end if;
+
+  if new.advisor_id = new.student_id then
+    raise exception 'The student cannot be their own advisor.';
+  end if;
+
+  select role
+    into selected_role
+  from public.profiles
+  where id = new.advisor_id;
+
+  if not found or selected_role not in (
+    'advisor'::public.app_role,
+    'coordinator'::public.app_role
+  ) then
+    raise exception 'Assigned advisor must have an advisor or coordinator role.';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger internships_validate_advisor_assignment
+before insert or update of advisor_id, student_id on public.internships
+for each row
+execute function public.validate_internship_advisor_assignment();
+
+revoke all on function public.validate_internship_advisor_assignment()
+from public, anon, authenticated;
+
+alter table public.activity_logs
+  add column review_comment text,
+  add column reviewed_by uuid references public.profiles(id) on delete restrict,
+  add column reviewed_at timestamptz,
+  add constraint activity_logs_review_comment_length
+    check (review_comment is null or char_length(review_comment) <= 2000),
+  add constraint activity_logs_review_metadata_consistent
+    check (
+      (status in ('draft'::public.activity_status, 'submitted'::public.activity_status)
+        and reviewed_by is null and reviewed_at is null)
+      or
+      (status in ('approved'::public.activity_status, 'rejected'::public.activity_status)
+        and reviewed_by is not null and reviewed_at is not null)
+    );
+
+create index activity_logs_reviewed_by_idx
+  on public.activity_logs (reviewed_by)
+  where reviewed_by is not null;
+
+create table public.activity_status_events (
+  id uuid primary key default gen_random_uuid(),
+  activity_id uuid not null references public.activity_logs(id) on delete cascade,
+  internship_id uuid not null references public.internships(id) on delete cascade,
+  student_id uuid not null references public.profiles(id) on delete restrict,
+  actor_id uuid not null references public.profiles(id) on delete restrict,
+  from_status public.activity_status,
+  to_status public.activity_status not null,
+  comment text,
+  created_at timestamptz not null default now(),
+  constraint activity_status_events_comment_length
+    check (comment is null or char_length(comment) <= 2000)
+);
+
+create index activity_status_events_activity_created_idx
+  on public.activity_status_events (activity_id, created_at desc);
+create index activity_status_events_internship_created_idx
+  on public.activity_status_events (internship_id, created_at desc);
+create index activity_status_events_student_created_idx
+  on public.activity_status_events (student_id, created_at desc);
+
+alter table public.activity_status_events enable row level security;
+revoke all on table public.activity_status_events from public, anon, authenticated;
+grant select on table public.activity_status_events to authenticated;
+grant select, insert, update, delete on table public.activity_status_events to service_role;
+
+create policy internships_select_assigned_advisor
+on public.internships
+for select
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and advisor_id = (select auth.uid())
+  and student_id <> (select auth.uid())
+);
+
+create policy profiles_select_assigned_students
+on public.profiles
+for select
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and id <> (select auth.uid())
+  and exists (
+    select 1
+    from public.internships i
+    where i.student_id = profiles.id
+      and i.advisor_id = (select auth.uid())
+  )
+);
+
+create policy activity_logs_select_assigned_advisor
+on public.activity_logs
+for select
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and student_id <> (select auth.uid())
+  and exists (
+    select 1
+    from public.internships i
+    where i.id = activity_logs.internship_id
+      and i.advisor_id = (select auth.uid())
+  )
+);
+
+create policy activity_logs_review_assigned_advisor
+on public.activity_logs
+for update
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and student_id <> (select auth.uid())
+  and status = 'submitted'::public.activity_status
+  and exists (
+    select 1
+    from public.internships i
+    where i.id = activity_logs.internship_id
+      and i.advisor_id = (select auth.uid())
+  )
+)
+with check (
+  (select auth.uid()) is not null
+  and student_id <> (select auth.uid())
+  and status in ('approved'::public.activity_status, 'rejected'::public.activity_status)
+  and reviewed_by = (select auth.uid())
+  and reviewed_at is not null
+  and exists (
+    select 1
+    from public.internships i
+    where i.id = activity_logs.internship_id
+      and i.advisor_id = (select auth.uid())
+  )
+);
+
+grant update (status, review_comment) on public.activity_logs to authenticated;
+
+create policy activity_status_events_select_own
+on public.activity_status_events
+for select
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and student_id = (select auth.uid())
+);
+
+create policy activity_status_events_select_assigned_advisor
+on public.activity_status_events
+for select
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and student_id <> (select auth.uid())
+  and exists (
+    select 1
+    from public.internships i
+    where i.id = activity_status_events.internship_id
+      and i.advisor_id = (select auth.uid())
+  )
+);
+
+create or replace function public.validate_and_prepare_activity_log()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  current_user_id uuid := auth.uid();
+  internship_student_id uuid;
+  internship_advisor_id uuid;
+  internship_status public.internship_status;
+  actor_role public.app_role;
+begin
+  if current_user_id is null then
+    raise exception 'Authenticated user is required.';
+  end if;
+
+  select student_id, advisor_id, status
+    into internship_student_id, internship_advisor_id, internship_status
+  from public.internships
+  where id = new.internship_id;
+
+  if not found then
+    raise exception 'Internship is not available.';
+  end if;
+
+  if tg_op = 'INSERT' then
+    if internship_student_id <> current_user_id then
+      raise exception 'Internship is not available for the current user.';
+    end if;
+
+    if internship_status <> 'active'::public.internship_status then
+      raise exception 'Activities can only be registered for an active internship.';
+    end if;
+
+    if new.end_time <= new.start_time then
+      raise exception 'End time must be after start time.';
+    end if;
+
+    new.student_id := current_user_id;
+    new.duration_minutes := floor(
+      extract(epoch from (new.end_time - new.start_time)) / 60
+    )::integer;
+    new.status := 'submitted'::public.activity_status;
+    new.review_comment := null;
+    new.reviewed_by := null;
+    new.reviewed_at := null;
+    return new;
+  end if;
+
+  if new.internship_id is distinct from old.internship_id
+     or new.student_id is distinct from old.student_id then
+    raise exception 'Protected activity fields cannot be changed.';
+  end if;
+
+  if current_user_id = old.student_id then
+    if old.status not in (
+      'draft'::public.activity_status,
+      'submitted'::public.activity_status
+    ) then
+      raise exception 'Reviewed activities cannot be changed by the student.';
+    end if;
+
+    if internship_status not in (
+      'active'::public.internship_status,
+      'paused'::public.internship_status
+    ) then
+      raise exception 'Activities cannot be changed for this internship state.';
+    end if;
+
+    if new.status is distinct from old.status
+       or new.review_comment is distinct from old.review_comment
+       or new.reviewed_by is distinct from old.reviewed_by
+       or new.reviewed_at is distinct from old.reviewed_at then
+      raise exception 'Students cannot review their own activities.';
+    end if;
+
+    if new.end_time <= new.start_time then
+      raise exception 'End time must be after start time.';
+    end if;
+
+    new.duration_minutes := floor(
+      extract(epoch from (new.end_time - new.start_time)) / 60
+    )::integer;
+    return new;
+  end if;
+
+  select role
+    into actor_role
+  from public.profiles
+  where id = current_user_id;
+
+  if current_user_id = internship_advisor_id
+     and current_user_id <> old.student_id
+     and actor_role in ('advisor'::public.app_role, 'coordinator'::public.app_role) then
+    if old.status <> 'submitted'::public.activity_status then
+      raise exception 'Only submitted activities can be reviewed.';
+    end if;
+
+    if new.status not in (
+      'approved'::public.activity_status,
+      'rejected'::public.activity_status
+    ) then
+      raise exception 'Review must approve or reject the activity.';
+    end if;
+
+    if new.activity_date is distinct from old.activity_date
+       or new.start_time is distinct from old.start_time
+       or new.end_time is distinct from old.end_time
+       or new.duration_minutes is distinct from old.duration_minutes
+       or new.group_label is distinct from old.group_label
+       or new.teacher_name is distinct from old.teacher_name
+       or new.description is distinct from old.description
+       or new.notes is distinct from old.notes then
+      raise exception 'Reviewers cannot alter the student activity content.';
+    end if;
+
+    if new.status = 'rejected'::public.activity_status
+       and (new.review_comment is null or char_length(btrim(new.review_comment)) < 3) then
+      raise exception 'Rejected activities require a review comment.';
+    end if;
+
+    new.review_comment := nullif(btrim(new.review_comment), '');
+    new.reviewed_by := current_user_id;
+    new.reviewed_at := now();
+    return new;
+  end if;
+
+  raise exception 'The current user cannot update this activity.';
+end;
+$$;
+
+create or replace function private.record_activity_status_event()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  current_user_id uuid := auth.uid();
+begin
+  if current_user_id is null then
+    raise exception 'Authenticated user is required to record activity history.';
+  end if;
+
+  if tg_op = 'INSERT' or new.status is distinct from old.status then
+    insert into public.activity_status_events (
+      activity_id,
+      internship_id,
+      student_id,
+      actor_id,
+      from_status,
+      to_status,
+      comment,
+      created_at
+    ) values (
+      new.id,
+      new.internship_id,
+      new.student_id,
+      current_user_id,
+      case when tg_op = 'INSERT' then null else old.status end,
+      new.status,
+      case when tg_op = 'INSERT' then null else new.review_comment end,
+      now()
+    );
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.record_activity_status_event()
+from public, anon, authenticated;
+
+create trigger activity_logs_record_status_event
+after insert or update of status on public.activity_logs
+for each row
+execute function private.record_activity_status_event();


### PR DESCRIPTION
Implementa a primeira revisão acadêmica de atividades.

Inclui:
- RLS para orientador atribuído;
- bloqueio de autoaprovação;
- aprovação/rejeição de atividades enviadas;
- justificativa obrigatória para rejeição;
- metadados de revisão;
- histórico append-only de status;
- área `/advisor` com fila e revisões recentes;
- navegação autenticada por papel;
- proteção de `/advisor` no Proxy.

Validação de banco em transação: autoaprovação bloqueada; orientador atribuído aprovou atividade; histórico gerou `submitted -> approved` com dois eventos e rollback.

Closes #47