### PR TITLE
feat: add coordinator advisor assignments

### DIFF
--- a/src/app/(protected)/coordination/page.tsx
+++ b/src/app/(protected)/coordination/page.tsx
@@ -1,0 +1,146 @@
+import { redirect } from "next/navigation";
+
+import { InternshipAssignmentCard } from "@/features/coordination/components/internship-assignment-card";
+import { getCoordinationWorkspace } from "@/features/coordination";
+
+type CoordinationPageProps = {
+  searchParams: Promise<{ updated?: string; error?: string }>;
+};
+
+export default async function CoordinationPage({
+  searchParams,
+}: CoordinationPageProps) {
+  const params = await searchParams;
+  const result = await getCoordinationWorkspace();
+
+  if (!result.ok && result.error.code === "coordinator_role_required") {
+    redirect("/advisor");
+  }
+
+  if (!result.ok) {
+    return (
+      <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8 dark:border-amber-900 dark:bg-amber-950/40">
+        <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+          Coordenação
+        </p>
+        <h1 className="mt-2 text-2xl font-bold text-amber-950 dark:text-amber-50">
+          Não foi possível carregar os vínculos agora.
+        </h1>
+      </section>
+    );
+  }
+
+  const workspace = result.data;
+  const assignedCount = workspace.internships.filter(
+    (internship) => internship.advisorId,
+  ).length;
+
+  return (
+    <div className="space-y-7 sm:space-y-9">
+      {params.updated === "1" ? (
+        <Notice tone="success">
+          Orientador atualizado. A fila de revisão já reflete o novo vínculo.
+        </Notice>
+      ) : null}
+
+      {params.error ? (
+        <Notice tone="error">
+          {params.error === "invalid"
+            ? "Selecione um orientador válido ou deixe o estágio sem orientador."
+            : "Não foi possível atualizar o vínculo. Tente novamente."}
+        </Notice>
+      ) : null}
+
+      <section>
+        <p className="text-sm font-semibold text-indigo-600 dark:text-indigo-400">
+          Coordenação
+        </p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950 dark:text-white">
+          Atribuição de orientadores
+        </h1>
+        <p className="mt-3 max-w-3xl text-base leading-7 text-slate-600 dark:text-slate-300">
+          Vincule cada estágio a um orientador responsável. O vínculo controla quem pode visualizar e revisar as atividades daquele estudante.
+        </p>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <Metric value={String(workspace.internships.length)} label="Estágios" />
+        <Metric value={String(assignedCount)} label="Com orientador" />
+        <Metric value={String(workspace.advisors.length)} label="Orientadores disponíveis" />
+      </section>
+
+      {workspace.advisors.length === 0 ? (
+        <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 sm:p-8 dark:border-amber-900 dark:bg-amber-950/40">
+          <h2 className="text-lg font-bold text-amber-950 dark:text-amber-50">
+            Ainda não existem perfis de orientador.
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-amber-800 dark:text-amber-200">
+            Esta tela só atribui perfis que já possuem papel de orientador ou coordenador. A gestão de papéis será tratada separadamente para manter essa permissão auditável.
+          </p>
+        </section>
+      ) : null}
+
+      <section>
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-indigo-600 dark:text-indigo-400">
+              Estágios
+            </p>
+            <h2 className="mt-1 text-xl font-bold text-slate-950 dark:text-white">
+              Responsáveis por acompanhamento
+            </h2>
+          </div>
+          <span className="text-sm text-slate-500 dark:text-slate-400">
+            {workspace.internships.length} registro(s)
+          </span>
+        </div>
+
+        {workspace.internships.length === 0 ? (
+          <div className="mt-4 rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center dark:border-slate-700 dark:bg-slate-900">
+            <p className="font-semibold text-slate-900 dark:text-white">
+              Nenhum estágio cadastrado ainda.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-4 space-y-4">
+            {workspace.internships.map((internship) => (
+              <InternshipAssignmentCard
+                key={internship.id}
+                internship={internship}
+                advisors={workspace.advisors}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Metric({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p className="text-2xl font-bold text-slate-950 dark:text-white">{value}</p>
+      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{label}</p>
+    </div>
+  );
+}
+
+function Notice({
+  tone,
+  children,
+}: {
+  tone: "success" | "error";
+  children: React.ReactNode;
+}) {
+  const classes =
+    tone === "success"
+      ? "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200"
+      : "border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200";
+
+  return (
+    <div className={`rounded-2xl border p-4 text-sm font-semibold ${classes}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/features/coordination/actions/coordination.actions.ts
+++ b/src/features/coordination/actions/coordination.actions.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { assignAdvisor } from "../repositories/coordination.repository";
+
+function field(formData: FormData, name: string) {
+  const value = formData.get(name);
+  return typeof value === "string" ? value : "";
+}
+
+export async function assignAdvisorAction(
+  internshipId: string,
+  formData: FormData,
+) {
+  const result = await assignAdvisor({
+    internshipId,
+    advisorId: field(formData, "advisorId"),
+  });
+
+  if (!result.ok) {
+    const reason =
+      result.error.code === "invalid_assignment_input" ||
+      result.error.code === "invalid_advisor"
+        ? "invalid"
+        : "database";
+    redirect(`/coordination?error=${reason}`);
+  }
+
+  revalidatePath("/coordination");
+  revalidatePath("/advisor");
+  revalidatePath("/activities");
+  redirect("/coordination?updated=1");
+}

--- a/src/features/coordination/components/internship-assignment-card.tsx
+++ b/src/features/coordination/components/internship-assignment-card.tsx
@@ -1,0 +1,92 @@
+import { assignAdvisorAction } from "../actions/coordination.actions";
+import type {
+  AdvisorCandidate,
+  CoordinationInternship,
+} from "../types";
+
+const STATUS_LABELS: Record<CoordinationInternship["status"], string> = {
+  draft: "Rascunho",
+  active: "Ativo",
+  paused: "Pausado",
+  completed: "Concluído",
+  cancelled: "Cancelado",
+};
+
+function dateLabel(date: string) {
+  return new Date(`${date}T12:00:00`).toLocaleDateString("pt-BR");
+}
+
+export function InternshipAssignmentCard({
+  internship,
+  advisors,
+}: {
+  internship: CoordinationInternship;
+  advisors: AdvisorCandidate[];
+}) {
+  const action = assignAdvisorAction.bind(null, internship.id);
+
+  return (
+    <article className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6 dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+              {STATUS_LABELS[internship.status]}
+            </span>
+            <span className="text-sm font-semibold text-slate-500 dark:text-slate-400">
+              Início em {dateLabel(internship.startDate)}
+            </span>
+          </div>
+
+          <h2 className="mt-3 text-lg font-bold text-slate-950 dark:text-white">
+            {internship.studentName}
+          </h2>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            {internship.registrationNumber
+              ? `Matrícula ${internship.registrationNumber} · `
+              : ""}
+            {internship.internshipTypeName}
+          </p>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            {internship.organizationName}
+          </p>
+
+          <div className="mt-4 rounded-2xl bg-slate-50 px-4 py-3 text-sm dark:bg-slate-950">
+            <span className="text-slate-500 dark:text-slate-400">Orientador atual: </span>
+            <span className="font-semibold text-slate-900 dark:text-white">
+              {internship.advisorName ?? "Não atribuído"}
+            </span>
+          </div>
+        </div>
+
+        <form action={action} className="w-full max-w-md shrink-0">
+          <label className="block">
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Orientador responsável
+            </span>
+            <select
+              name="advisorId"
+              defaultValue={internship.advisorId ?? ""}
+              className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-4 text-sm text-slate-950 outline-none transition focus:border-indigo-500 focus:ring-4 focus:ring-indigo-500/10 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            >
+              <option value="">Sem orientador</option>
+              {advisors.map((advisor) => (
+                <option key={advisor.id} value={advisor.id}>
+                  {advisor.fullName}
+                  {advisor.role === "coordinator" ? " · Coordenador" : ""}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <button
+            type="submit"
+            className="mt-3 inline-flex h-11 w-full items-center justify-center rounded-xl bg-indigo-600 px-5 text-sm font-bold text-white transition hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+          >
+            Salvar vínculo
+          </button>
+        </form>
+      </div>
+    </article>
+  );
+}

--- a/src/features/coordination/index.ts
+++ b/src/features/coordination/index.ts
@@ -1,0 +1,12 @@
+export { assignAdvisorAction } from "./actions/coordination.actions";
+export {
+  assignAdvisor,
+  getCoordinationWorkspace,
+} from "./repositories/coordination.repository";
+export type {
+  AdvisorCandidate,
+  CoordinationError,
+  CoordinationInternship,
+  CoordinationResult,
+  CoordinationWorkspace,
+} from "./types";

--- a/src/features/coordination/repositories/coordination.repository.ts
+++ b/src/features/coordination/repositories/coordination.repository.ts
@@ -1,0 +1,227 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import { createClient } from "@/lib/supabase/server";
+import type { TablesUpdate } from "@/types/database";
+
+import {
+  advisorAssignmentInputSchema,
+  type AdvisorAssignmentInput,
+} from "../schemas/advisor-assignment.schema";
+import type {
+  AdvisorCandidate,
+  CoordinationInternship,
+  CoordinationResult,
+  CoordinationWorkspace,
+} from "../types";
+
+function repositoryError(code: string, message: string): CoordinationResult<never> {
+  return { ok: false, error: { code, message } };
+}
+
+function databaseError(error: PostgrestError): CoordinationResult<never> {
+  return repositoryError(error.code, error.message);
+}
+
+async function getCoordinatorContext() {
+  const supabase = await createClient();
+  const { data: claimsData, error: claimsError } = await supabase.auth.getClaims();
+  const userId = claimsData?.claims?.sub;
+
+  if (claimsError || !userId) {
+    return {
+      ok: false as const,
+      error: {
+        code: claimsError?.code ?? "not_authenticated",
+        message: claimsError?.message ?? "Usuário autenticado é obrigatório.",
+      },
+    };
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("full_name,role")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (profileError) {
+    return { ok: false as const, error: profileError };
+  }
+
+  if (!profile || profile.role !== "coordinator") {
+    return {
+      ok: false as const,
+      error: {
+        code: "coordinator_role_required",
+        message: "Esta área é exclusiva para coordenadores.",
+      },
+    };
+  }
+
+  return {
+    ok: true as const,
+    supabase,
+    userId,
+    coordinatorName: profile.full_name,
+  };
+}
+
+type RawProfile = {
+  id: string;
+  full_name: string;
+  role: "advisor" | "coordinator";
+};
+
+type RawCoordinationInternship = {
+  id: string;
+  status: CoordinationInternship["status"];
+  start_date: string;
+  advisor_id: string | null;
+  student_id: string;
+  student: {
+    id: string;
+    full_name: string;
+    registration_number: string | null;
+  } | null;
+  advisor: {
+    id: string;
+    full_name: string;
+    role: "advisor" | "coordinator";
+  } | null;
+  internship_types: { name: string } | null;
+  organizations: { name: string } | null;
+};
+
+function mapAdvisor(profile: RawProfile): AdvisorCandidate {
+  return {
+    id: profile.id,
+    fullName: profile.full_name,
+    role: profile.role,
+  };
+}
+
+function mapInternship(row: RawCoordinationInternship): CoordinationInternship {
+  return {
+    id: row.id,
+    status: row.status,
+    startDate: row.start_date,
+    advisorId: row.advisor_id,
+    advisorName: row.advisor?.full_name ?? null,
+    studentId: row.student_id,
+    studentName: row.student?.full_name ?? "Estudante",
+    registrationNumber: row.student?.registration_number ?? null,
+    internshipTypeName: row.internship_types?.name ?? "Estágio",
+    organizationName: row.organizations?.name ?? "Concedente não informada",
+  };
+}
+
+export async function getCoordinationWorkspace(): Promise<
+  CoordinationResult<CoordinationWorkspace>
+> {
+  const context = await getCoordinatorContext();
+
+  if (!context.ok) {
+    return { ok: false, error: context.error };
+  }
+
+  const [advisorResult, internshipResult] = await Promise.all([
+    context.supabase
+      .from("profiles")
+      .select("id,full_name,role")
+      .in("role", ["advisor", "coordinator"])
+      .order("full_name"),
+    context.supabase
+      .from("internships")
+      .select(
+        "id,status,start_date,advisor_id,student_id,student:profiles!internships_student_id_fkey(id,full_name,registration_number),advisor:profiles!internships_advisor_id_fkey(id,full_name,role),internship_types(name),organizations(name)",
+      )
+      .order("created_at", { ascending: false }),
+  ]);
+
+  if (advisorResult.error) {
+    return databaseError(advisorResult.error);
+  }
+
+  if (internshipResult.error) {
+    return databaseError(internshipResult.error);
+  }
+
+  return {
+    ok: true,
+    data: {
+      coordinatorName: context.coordinatorName,
+      advisors: (advisorResult.data as RawProfile[]).map(mapAdvisor),
+      internships: (internshipResult.data as unknown as RawCoordinationInternship[]).map(
+        mapInternship,
+      ),
+    },
+  };
+}
+
+export async function assignAdvisor(
+  input: AdvisorAssignmentInput,
+): Promise<CoordinationResult<{ id: string; advisorId: string | null }>> {
+  const parsed = advisorAssignmentInputSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return repositoryError(
+      "invalid_assignment_input",
+      parsed.error.issues[0]?.message ?? "Vínculo de orientador inválido.",
+    );
+  }
+
+  const context = await getCoordinatorContext();
+
+  if (!context.ok) {
+    return { ok: false, error: context.error };
+  }
+
+  if (parsed.data.advisorId) {
+    const { data: candidate, error: candidateError } = await context.supabase
+      .from("profiles")
+      .select("id,role")
+      .eq("id", parsed.data.advisorId)
+      .in("role", ["advisor", "coordinator"])
+      .maybeSingle();
+
+    if (candidateError) {
+      return databaseError(candidateError);
+    }
+
+    if (!candidate) {
+      return repositoryError(
+        "invalid_advisor",
+        "O perfil selecionado não pode atuar como orientador.",
+      );
+    }
+  }
+
+  const payload: TablesUpdate<"internships"> = {
+    advisor_id: parsed.data.advisorId,
+  };
+
+  const { data, error } = await context.supabase
+    .from("internships")
+    .update(payload)
+    .eq("id", parsed.data.internshipId)
+    .select("id,advisor_id")
+    .maybeSingle();
+
+  if (error) {
+    return databaseError(error);
+  }
+
+  if (!data) {
+    return repositoryError(
+      "internship_not_assignable",
+      "O estágio não foi encontrado ou não está disponível para atribuição.",
+    );
+  }
+
+  return {
+    ok: true,
+    data: {
+      id: data.id,
+      advisorId: data.advisor_id,
+    },
+  };
+}

--- a/src/features/coordination/schemas/advisor-assignment.schema.ts
+++ b/src/features/coordination/schemas/advisor-assignment.schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const advisorAssignmentInputSchema = z.object({
+  internshipId: z.uuid(),
+  advisorId: z
+    .union([z.uuid(), z.literal("")])
+    .transform((value) => (value.length > 0 ? value : null)),
+});
+
+export type AdvisorAssignmentInput = z.infer<typeof advisorAssignmentInputSchema>;

--- a/src/features/coordination/types.ts
+++ b/src/features/coordination/types.ts
@@ -1,0 +1,35 @@
+import type { Tables } from "@/types/database";
+
+export type CoordinationError = {
+  code: string;
+  message: string;
+};
+
+export type CoordinationResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: CoordinationError };
+
+export type AdvisorCandidate = {
+  id: string;
+  fullName: string;
+  role: "advisor" | "coordinator";
+};
+
+export type CoordinationInternship = {
+  id: string;
+  status: Tables<"internships">["status"];
+  startDate: string;
+  advisorId: string | null;
+  advisorName: string | null;
+  studentId: string;
+  studentName: string;
+  registrationNumber: string | null;
+  internshipTypeName: string;
+  organizationName: string;
+};
+
+export type CoordinationWorkspace = {
+  coordinatorName: string;
+  advisors: AdvisorCandidate[];
+  internships: CoordinationInternship[];
+};

--- a/src/features/navigation/components/mobile-navigation.tsx
+++ b/src/features/navigation/components/mobile-navigation.tsx
@@ -13,7 +13,12 @@ import { NavigationIcon } from "./navigation-icon";
 export function MobileNavigation({ role }: { role: NavigationRole }) {
   const pathname = usePathname();
   const navigation = getAuthenticatedNavigation(role);
-  const gridClass = navigation.length === 2 ? "grid-cols-2" : "grid-cols-4";
+  const gridClass =
+    navigation.length === 2
+      ? "grid-cols-2"
+      : navigation.length === 3
+        ? "grid-cols-3"
+        : "grid-cols-4";
 
   return (
     <nav

--- a/src/features/navigation/components/navigation-icon.tsx
+++ b/src/features/navigation/components/navigation-icon.tsx
@@ -49,6 +49,15 @@ export function NavigationIcon({
           <path d="M9 18h6" />
         </svg>
       );
+    case "coordination":
+      return (
+        <svg {...common}>
+          <circle cx="9" cy="8" r="3" />
+          <path d="M3.5 19a5.5 5.5 0 0 1 11 0" />
+          <circle cx="17" cy="9" r="2.25" />
+          <path d="M15.5 14.5a4.25 4.25 0 0 1 5 4.2" />
+        </svg>
+      );
     case "profile":
       return (
         <svg {...common}>

--- a/src/features/navigation/components/sidebar.tsx
+++ b/src/features/navigation/components/sidebar.tsx
@@ -20,12 +20,20 @@ type SidebarProps = {
 };
 
 function initials(name: string) {
-  return name
-    .trim()
-    .split(/\s+/)
-    .slice(0, 2)
-    .map((part) => part[0]?.toUpperCase())
-    .join("") || "ST";
+  return (
+    name
+      .trim()
+      .split(/\s+/)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase())
+      .join("") || "ST"
+  );
+}
+
+function homeHref(role: NavigationRole) {
+  if (role === "student") return "/dashboard";
+  if (role === "coordinator") return "/coordination";
+  return "/advisor";
 }
 
 export function Sidebar({ displayName, roleLabel, role, email }: SidebarProps) {
@@ -35,7 +43,7 @@ export function Sidebar({ displayName, roleLabel, role, email }: SidebarProps) {
   return (
     <aside className="hidden h-screen w-72 shrink-0 border-r border-slate-200 bg-white lg:sticky lg:top-0 lg:flex lg:flex-col dark:border-slate-800 dark:bg-slate-950">
       <div className="border-b border-slate-100 px-6 py-7 dark:border-slate-800">
-        <Link href={role === "student" ? "/dashboard" : "/advisor"} className="inline-flex items-center gap-3 group">
+        <Link href={homeHref(role)} className="inline-flex items-center gap-3 group">
           <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-indigo-600 text-sm font-black tracking-tight text-white shadow-sm shadow-indigo-200 transition group-hover:bg-indigo-500 dark:shadow-none">
             ST
           </span>

--- a/src/features/navigation/config/authenticated-navigation.ts
+++ b/src/features/navigation/config/authenticated-navigation.ts
@@ -3,6 +3,7 @@ export type NavigationIconName =
   | "internship"
   | "activities"
   | "review"
+  | "coordination"
   | "profile";
 
 export type NavigationRole = "student" | "advisor" | "coordinator";
@@ -46,7 +47,31 @@ const studentNavigation = [
   },
 ] as const satisfies readonly AuthenticatedNavigationItem[];
 
-const reviewerNavigation = [
+const advisorNavigation = [
+  {
+    href: "/advisor",
+    label: "Revisões",
+    mobileLabel: "Revisões",
+    description: "Fila de atividades dos seus estudantes",
+    icon: "review",
+  },
+  {
+    href: "/profile",
+    label: "Perfil",
+    mobileLabel: "Perfil",
+    description: "Dados acadêmicos e da conta",
+    icon: "profile",
+  },
+] as const satisfies readonly AuthenticatedNavigationItem[];
+
+const coordinatorNavigation = [
+  {
+    href: "/coordination",
+    label: "Coordenação",
+    mobileLabel: "Coordenação",
+    description: "Atribuição de orientadores aos estágios",
+    icon: "coordination",
+  },
   {
     href: "/advisor",
     label: "Revisões",
@@ -64,7 +89,15 @@ const reviewerNavigation = [
 ] as const satisfies readonly AuthenticatedNavigationItem[];
 
 export function getAuthenticatedNavigation(role: NavigationRole) {
-  return role === "student" ? studentNavigation : reviewerNavigation;
+  if (role === "student") {
+    return studentNavigation;
+  }
+
+  if (role === "coordinator") {
+    return coordinatorNavigation;
+  }
+
+  return advisorNavigation;
 }
 
 export function isNavigationItemActive(pathname: string, href: string) {

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -8,6 +8,7 @@ const PRIVATE_ROUTE_PREFIXES = [
   "/internships",
   "/activities",
   "/advisor",
+  "/coordination",
   "/profile",
 ] as const;
 

--- a/supabase/migrations/20260902231940_add_coordinator_advisor_assignment.sql
+++ b/supabase/migrations/20260902231940_add_coordinator_advisor_assignment.sql
@@ -1,0 +1,167 @@
+create or replace function private.current_app_role()
+returns public.app_role
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select role
+  from public.profiles
+  where id = auth.uid()
+$$;
+
+grant usage on schema private to authenticated;
+grant execute on function private.current_app_role() to authenticated;
+
+create policy profiles_select_coordination
+on public.profiles
+for select
+to authenticated
+using (private.current_app_role() = 'coordinator'::public.app_role);
+
+create policy internships_select_coordination
+on public.internships
+for select
+to authenticated
+using (private.current_app_role() = 'coordinator'::public.app_role);
+
+create policy internships_update_advisor_coordination
+on public.internships
+for update
+to authenticated
+using (private.current_app_role() = 'coordinator'::public.app_role)
+with check (private.current_app_role() = 'coordinator'::public.app_role);
+
+grant update (advisor_id) on public.internships to authenticated;
+
+create or replace function public.validate_and_prepare_internship()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  current_user_id uuid := auth.uid();
+  actor_role public.app_role;
+  selected_course_id uuid;
+  selected_required_minutes integer;
+  selected_type_active boolean;
+  student_course_id uuid;
+begin
+  if current_user_id is not null then
+    select role into actor_role
+    from public.profiles
+    where id = current_user_id;
+  end if;
+
+  if tg_op = 'INSERT' and current_user_id is not null then
+    new.student_id := current_user_id;
+  end if;
+
+  if tg_op = 'UPDATE' and current_user_id is not null then
+    if actor_role = 'coordinator'::public.app_role then
+      if new.student_id is distinct from old.student_id
+         or new.internship_type_id is distinct from old.internship_type_id
+         or new.organization_id is distinct from old.organization_id
+         or new.supervisor_id is distinct from old.supervisor_id
+         or new.start_date is distinct from old.start_date
+         or new.expected_end_date is distinct from old.expected_end_date
+         or new.required_minutes is distinct from old.required_minutes
+         or new.status is distinct from old.status
+         or new.created_at is distinct from old.created_at then
+        raise exception 'Coordinators can only change the assigned advisor.';
+      end if;
+
+      return new;
+    end if;
+
+    if current_user_id <> old.student_id then
+      raise exception 'The current user cannot update this internship.';
+    end if;
+
+    if old.status in (
+      'completed'::public.internship_status,
+      'cancelled'::public.internship_status
+    ) then
+      raise exception 'Completed or cancelled internships cannot be changed by the student.';
+    end if;
+
+    if new.student_id is distinct from old.student_id
+       or new.required_minutes is distinct from old.required_minutes
+       or new.advisor_id is distinct from old.advisor_id then
+      raise exception 'Protected internship fields cannot be changed by the student.';
+    end if;
+
+    if new.internship_type_id is distinct from old.internship_type_id
+       and old.status <> 'draft'::public.internship_status then
+      raise exception 'Internship type can only be changed while the internship is a draft.';
+    end if;
+
+    if new.status is distinct from old.status then
+      if old.status = 'draft'::public.internship_status
+         and new.status not in (
+           'active'::public.internship_status,
+           'cancelled'::public.internship_status
+         ) then
+        raise exception 'Invalid internship status transition.';
+      elsif old.status = 'active'::public.internship_status
+         and new.status not in (
+           'paused'::public.internship_status,
+           'cancelled'::public.internship_status
+         ) then
+        raise exception 'Invalid internship status transition.';
+      elsif old.status = 'paused'::public.internship_status
+         and new.status not in (
+           'active'::public.internship_status,
+           'cancelled'::public.internship_status
+         ) then
+        raise exception 'Invalid internship status transition.';
+      end if;
+    end if;
+  end if;
+
+  if tg_op = 'INSERT'
+     or new.internship_type_id is distinct from old.internship_type_id then
+    select course_id, required_minutes, active
+      into selected_course_id, selected_required_minutes, selected_type_active
+    from public.internship_types
+    where id = new.internship_type_id;
+
+    if not found then
+      raise exception 'Internship type is not available.';
+    end if;
+
+    if selected_type_active is not true then
+      raise exception 'Inactive internship types cannot be used for a new internship.';
+    end if;
+
+    select course_id
+      into student_course_id
+    from public.profiles
+    where id = new.student_id;
+
+    if not found or student_course_id is null then
+      raise exception 'Student profile must have a course before creating an internship.';
+    end if;
+
+    if student_course_id <> selected_course_id then
+      raise exception 'Internship type does not belong to the student course.';
+    end if;
+
+    new.required_minutes := selected_required_minutes;
+  end if;
+
+  if new.supervisor_id is not null then
+    perform 1
+    from public.supervisors
+    where id = new.supervisor_id
+      and organization_id = new.organization_id;
+
+    if not found then
+      raise exception 'Supervisor is not available for the selected organization.';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build"
+}


### PR DESCRIPTION
Implementa a gestão de vínculo entre estágio e orientador pela coordenação.

Inclui:
- policies de leitura para coordenadores;
- update de `advisor_id` protegido por RLS + trigger;
- bloqueio de alterações em outros campos do estágio pelo coordenador;
- validação de que o orientador possui papel `advisor` ou `coordinator`;
- área `/coordination`;
- repository e Server Action dedicados;
- navegação desktop/mobile por papel;
- proteção da rota no Proxy;
- `vercel.json` para restaurar deploys Git nativos (`npm ci` + `npm run build`).

Validação transacional no Supabase: coordenador conseguiu atribuir orientador e tentativa de alterar o status do estágio foi bloqueada. Security advisor sem novos alertas além do aviso global de leaked-password protection.

Validação final: `npm ci`, lint, typecheck e build verdes.

Closes #50