### PR TITLE
fix: limit Vercel Git deploys to main

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,11 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "npm ci",
-  "buildCommand": "npm run build"
+  "buildCommand": "npm run build",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  }
 }


### PR DESCRIPTION
Evita consumir o limite de builds do plano Hobby com previews de cada commit.

- mantém deploy automático da `main`;
- desabilita deploy automático das demais branches via `git.deploymentEnabled`;
- preserva build nativo com `npm ci` + `npm run build`.

Validação final: `npm ci`, lint, typecheck e build verdes.

Closes #52